### PR TITLE
Fix menu bar icon crash and add configurable polling interval

### DIFF
--- a/Sources/ClaudeUsageBar/MenuBarIconRenderer.swift
+++ b/Sources/ClaudeUsageBar/MenuBarIconRenderer.swift
@@ -13,24 +13,32 @@ private let iconWidth: CGFloat = logoSize + logoGap + barsWidth
 private let iconHeight: CGFloat = 18
 private let fontSize: CGFloat = 8
 
-private func makeAttrs() -> [NSAttributedString.Key: Any] {
-    [
-        .font: NSFont.monospacedSystemFont(ofSize: fontSize, weight: .medium),
-        .foregroundColor: NSColor.black,
-    ]
+private struct CachedLabel {
+    let string: NSAttributedString
+    let size: NSSize
 }
 
-private func drawRow(label: String, barX: CGFloat, barY: CGFloat, attrs: [NSAttributedString.Key: Any], labelX: CGFloat, drawBarFill: (CGFloat, CGFloat) -> Void) {
-    let str = NSAttributedString(string: label, attributes: attrs)
-    let labelSize = str.size()
-    let labelY = barY + (barHeight - labelSize.height) / 2
-    str.draw(at: NSPoint(x: labelX + labelWidth - labelSize.width, y: labelY))
+private let cachedLabels: [String: CachedLabel] = {
+    let font = NSFont.monospacedSystemFont(ofSize: fontSize, weight: .medium)
+    let attrs: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: NSColor.black]
+    var result = [String: CachedLabel]()
+    for label in ["5h", "7d"] {
+        let str = NSAttributedString(string: label, attributes: attrs)
+        result[label] = CachedLabel(string: str, size: str.size())
+    }
+    return result
+}()
+
+private func drawRow(label: String, barX: CGFloat, barY: CGFloat, labelX: CGFloat, drawBarFill: (CGFloat, CGFloat) -> Void) {
+    if let cached = cachedLabels[label] {
+        let labelY = barY + (barHeight - cached.size.height) / 2
+        cached.string.draw(at: NSPoint(x: labelX + labelWidth - cached.size.width, y: labelY))
+    }
     drawBarFill(barX, barY)
 }
 
 func renderIcon(pct5h: Double, pct7d: Double) -> NSImage {
     let image = NSImage(size: NSSize(width: iconWidth, height: iconHeight), flipped: true) { _ in
-        let attrs = makeAttrs()
         let offset = logoSize + logoGap
         let barX = offset + labelWidth + labelGap
         let topY = (iconHeight - barHeight * 2 - rowGap) / 2
@@ -38,10 +46,10 @@ func renderIcon(pct5h: Double, pct7d: Double) -> NSImage {
 
         drawClaudeLogo(x: 0, y: (iconHeight - logoSize) / 2, size: logoSize)
 
-        drawRow(label: "5h", barX: barX, barY: topY, attrs: attrs, labelX: offset) { x, y in
+        drawRow(label: "5h", barX: barX, barY: topY, labelX: offset) { x, y in
             drawBar(x: x, y: y, width: barWidth, height: barHeight, cornerRadius: cornerRadius, pct: pct5h)
         }
-        drawRow(label: "7d", barX: barX, barY: bottomY, attrs: attrs, labelX: offset) { x, y in
+        drawRow(label: "7d", barX: barX, barY: bottomY, labelX: offset) { x, y in
             drawBar(x: x, y: y, width: barWidth, height: barHeight, cornerRadius: cornerRadius, pct: pct7d)
         }
         return true
@@ -52,7 +60,6 @@ func renderIcon(pct5h: Double, pct7d: Double) -> NSImage {
 
 func renderUnauthenticatedIcon() -> NSImage {
     let image = NSImage(size: NSSize(width: iconWidth, height: iconHeight), flipped: true) { _ in
-        let attrs = makeAttrs()
         let offset = logoSize + logoGap
         let barX = offset + labelWidth + labelGap
         let topY = (iconHeight - barHeight * 2 - rowGap) / 2
@@ -60,10 +67,10 @@ func renderUnauthenticatedIcon() -> NSImage {
 
         drawClaudeLogo(x: 0, y: (iconHeight - logoSize) / 2, size: logoSize)
 
-        drawRow(label: "5h", barX: barX, barY: topY, attrs: attrs, labelX: offset) { x, y in
+        drawRow(label: "5h", barX: barX, barY: topY, labelX: offset) { x, y in
             drawDashedBar(x: x, y: y, width: barWidth, height: barHeight, cornerRadius: cornerRadius)
         }
-        drawRow(label: "7d", barX: barX, barY: bottomY, attrs: attrs, labelX: offset) { x, y in
+        drawRow(label: "7d", barX: barX, barY: bottomY, labelX: offset) { x, y in
             drawDashedBar(x: x, y: y, width: barWidth, height: barHeight, cornerRadius: cornerRadius)
         }
         return true

--- a/Sources/ClaudeUsageBar/PopoverView.swift
+++ b/Sources/ClaudeUsageBar/PopoverView.swift
@@ -118,6 +118,32 @@ struct PopoverView: View {
                     .foregroundStyle(.secondary)
             }
             Spacer()
+            Text("Polling every")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                
+            Picker("", selection: $service.pollingMinutes) {
+                ForEach(UsageService.pollingOptions, id: \.self) { mins in
+                    Text(mins < 60 ? "\(mins)m" : "\(mins / 60)h").tag(mins)
+                }
+            }
+            .pickerStyle(.menu)
+            .controlSize(.mini)
+            .frame(width: 60)
+            .help("Polling interval")
+        }
+
+        HStack(spacing: 12) {
+          Toggle("Launch at Login", isOn: Binding(
+              get: { SMAppService.mainApp.status == .enabled },
+              set: { setLaunchAtLogin($0) }
+          ))
+          .toggleStyle(.switch)
+          .controlSize(.mini)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+
+            Spacer()
             Button("Refresh") {
                 Task { await service.fetchUsage() }
             }
@@ -132,15 +158,6 @@ struct PopoverView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
-
-        Toggle("Launch at Login", isOn: Binding(
-            get: { SMAppService.mainApp.status == .enabled },
-            set: { setLaunchAtLogin($0) }
-        ))
-        .toggleStyle(.switch)
-        .controlSize(.mini)
-        .font(.caption)
-        .foregroundStyle(.secondary)
     }
 }
 

--- a/Sources/ClaudeUsageBar/UsageService.swift
+++ b/Sources/ClaudeUsageBar/UsageService.swift
@@ -15,8 +15,20 @@ class UsageService: ObservableObject {
 
     private var timer: AnyCancellable?
     private let usageEndpoint = URL(string: "https://api.anthropic.com/api/oauth/usage")!
-    private let baseInterval: TimeInterval = 60
-    private var currentInterval: TimeInterval = 60
+    private var currentInterval: TimeInterval
+
+    static let defaultPollingMinutes = 30
+    static let pollingOptions = [5, 15, 30, 60]
+
+    @Published var pollingMinutes: Int {
+        didSet {
+            UserDefaults.standard.set(pollingMinutes, forKey: "pollingMinutes")
+            currentInterval = TimeInterval(pollingMinutes * 60)
+            if isAuthenticated { scheduleTimer() }
+        }
+    }
+
+    private var baseInterval: TimeInterval { TimeInterval(pollingMinutes * 60) }
 
     // OAuth constants
     private let clientId = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
@@ -41,6 +53,10 @@ class UsageService: ObservableObject {
     var reset7d: Date? { usage?.sevenDay?.resetsAtDate }
 
     init() {
+        let stored = UserDefaults.standard.integer(forKey: "pollingMinutes")
+        let minutes = Self.pollingOptions.contains(stored) ? stored : Self.defaultPollingMinutes
+        self.pollingMinutes = minutes
+        self.currentInterval = TimeInterval(minutes * 60)
         isAuthenticated = loadToken() != nil
     }
 


### PR DESCRIPTION
## Summary

- Fix crash in `MenuBarIconRenderer` caused by CoreText font attribute resolution producing nil values when macOS re-renders the template image for the status bar replicant. Labels and sizes are now cached at static init time.
- Replace hardcoded 60s API polling with a user-configurable interval (5m, 15m, 30m, 1h), defaulting to 30m, persisted via UserDefaults.
- Add polling interval picker to the popover UI.

## Test plan

- [ ] Launch app and verify menu bar icon renders without crashing
- [ ] Open popover and change polling interval via the dropdown
- [ ] Quit and relaunch — verify the selected interval persists
- [ ] Confirm the "Refresh" button still triggers an immediate fetch

Made with [Cursor](https://cursor.com)