### PR TITLE
Harden auth token storage and fix extra usage display

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,21 @@ Click the icon anytime to see:
 
 ## Data storage
 
-All data is stored locally in `~/.config/claude-usage-bar/`:
+Usage history is stored locally in `~/.config/claude-usage-bar/`:
 
 | File | Purpose |
 |------|---------|
-| `token` | OAuth access token (permissions: `0600`) |
 | `history.json` | Usage history for the chart (30-day retention) |
 
+The OAuth access token is stored in the macOS Keychain instead of a plaintext file. Existing installs using `~/.config/claude-usage-bar/token` are migrated on next launch and the legacy file is removed.
+
 History is buffered in memory and flushed to disk every 5 minutes and on app quit. No data is sent anywhere other than the Anthropic API.
+
+## Security notes
+
+- The app only talks to Anthropic OAuth and usage endpoints.
+- It uses PKCE for browser-based OAuth sign-in.
+- The current OAuth scope remains `user:profile user:inference` to preserve compatibility with Anthropic's existing usage integration until a narrower documented scope is confirmed.
 
 ## Development
 

--- a/Sources/ClaudeUsageBar/PopoverView.swift
+++ b/Sources/ClaudeUsageBar/PopoverView.swift
@@ -170,7 +170,7 @@ private struct CodeEntryView: View {
 
         HStack {
             Button("Cancel") {
-                service.isAwaitingCode = false
+                service.cancelOAuthFlow()
             }
             .buttonStyle(.borderless)
             Spacer()
@@ -218,14 +218,22 @@ private struct UsageBucketRow: View {
 
 private struct ExtraUsageRow: View {
     let extra: ExtraUsage
+    private static let currencyFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.maximumFractionDigits = 2
+        formatter.minimumFractionDigits = 2
+        formatter.locale = .current
+        return formatter
+    }()
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             Text("Extra Usage")
                 .font(.subheadline)
-            if let used = extra.usedCredits, let limit = extra.monthlyLimit {
+            if let used = extra.usedCreditsAmount, let limit = extra.monthlyLimitAmount {
                 HStack {
-                    Text(String(format: "$%.2f / $%.2f", used, limit))
+                    Text("\(formatCurrency(used)) / \(formatCurrency(limit))")
                         .font(.caption)
                         .monospacedDigit()
                     Spacer()
@@ -239,6 +247,11 @@ private struct ExtraUsageRow: View {
                     .tint(.blue)
             }
         }
+    }
+
+    private func formatCurrency(_ amount: Double) -> String {
+        Self.currencyFormatter.string(from: NSNumber(value: amount))
+            ?? String(format: "%.2f", amount)
     }
 }
 

--- a/Sources/ClaudeUsageBar/UsageModel.swift
+++ b/Sources/ClaudeUsageBar/UsageModel.swift
@@ -49,4 +49,12 @@ struct ExtraUsage: Codable {
         case usedCredits = "used_credits"
         case monthlyLimit = "monthly_limit"
     }
+
+    var usedCreditsAmount: Double? {
+        usedCredits.map { $0 / 100.0 }
+    }
+
+    var monthlyLimitAmount: Double? {
+        monthlyLimit.map { $0 / 100.0 }
+    }
 }

--- a/Sources/ClaudeUsageBar/UsageService.swift
+++ b/Sources/ClaudeUsageBar/UsageService.swift
@@ -2,6 +2,7 @@ import Foundation
 import Combine
 import CryptoKit
 import AppKit
+import Security
 
 @MainActor
 class UsageService: ObservableObject {
@@ -17,6 +18,9 @@ class UsageService: ObservableObject {
     private let usageEndpoint = URL(string: "https://api.anthropic.com/api/oauth/usage")!
     private let baseInterval: TimeInterval = 60
     private var currentInterval: TimeInterval = 60
+    private static let oauthScope = "user:profile user:inference"
+    private static let keychainService = "com.local.ClaudeUsageBar"
+    private static let keychainAccount = "anthropic-oauth-token"
 
     // OAuth constants
     private let clientId = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
@@ -27,8 +31,8 @@ class UsageService: ObservableObject {
     private var codeVerifier: String?
     private var oauthState: String?
 
-    // File-based token storage (avoids Keychain prompts for unsigned binaries)
-    private static var tokenFileURL: URL {
+    // Legacy file token path kept only for migration from older installs.
+    private static var legacyTokenFileURL: URL {
         let dir = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".config/claude-usage-bar", isDirectory: true)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -78,16 +82,25 @@ class UsageService: ObservableObject {
             URLQueryItem(name: "client_id", value: clientId),
             URLQueryItem(name: "response_type", value: "code"),
             URLQueryItem(name: "redirect_uri", value: redirectUri),
-            URLQueryItem(name: "scope", value: "user:profile user:inference"),
+            URLQueryItem(name: "scope", value: Self.oauthScope),
             URLQueryItem(name: "code_challenge", value: challenge),
             URLQueryItem(name: "code_challenge_method", value: "S256"),
             URLQueryItem(name: "state", value: state),
         ]
 
         if let url = components.url {
-            NSWorkspace.shared.open(url)
-            isAwaitingCode = true
+            lastError = nil
+            if NSWorkspace.shared.open(url) {
+                isAwaitingCode = true
+            } else {
+                clearPendingOAuthFlow(clearError: false)
+                lastError = "Could not open the browser for Claude sign-in"
+            }
         }
+    }
+
+    func cancelOAuthFlow() {
+        clearPendingOAuthFlow(clearError: false)
     }
 
     func submitOAuthCode(_ rawCode: String) async {
@@ -99,16 +112,14 @@ class UsageService: ObservableObject {
             let returnedState = String(parts[1])
             guard returnedState == oauthState else {
                 lastError = "OAuth state mismatch — try again"
-                isAwaitingCode = false
-                codeVerifier = nil
-                oauthState = nil
+                clearPendingOAuthFlow(clearError: false)
                 return
             }
         }
 
         guard let verifier = codeVerifier else {
             lastError = "No pending OAuth flow"
-            isAwaitingCode = false
+            clearPendingOAuthFlow(clearError: false)
             return
         }
 
@@ -145,12 +156,13 @@ class UsageService: ObservableObject {
                 return
             }
 
-            saveToken(accessToken)
+            guard saveToken(accessToken) else {
+                lastError = "Could not store session securely in macOS Keychain"
+                clearPendingOAuthFlow(clearError: false)
+                return
+            }
             isAuthenticated = true
-            isAwaitingCode = false
-            lastError = nil
-            codeVerifier = nil
-            oauthState = nil
+            clearPendingOAuthFlow(clearError: true)
 
             startPolling()
         } catch {
@@ -229,24 +241,99 @@ class UsageService: ObservableObject {
         }
     }
 
-    // MARK: - File-based token storage
+    private func clearPendingOAuthFlow(clearError: Bool) {
+        isAwaitingCode = false
+        codeVerifier = nil
+        oauthState = nil
+        if clearError {
+            lastError = nil
+        }
+    }
 
-    private func saveToken(_ token: String) {
-        let url = Self.tokenFileURL
-        try? Data(token.utf8).write(to: url, options: .atomic)
-        // Restrict permissions to owner-only (0600)
-        try? FileManager.default.setAttributes(
-            [.posixPermissions: 0o600], ofItemAtPath: url.path)
+    // MARK: - Keychain token storage
+
+    private func saveToken(_ token: String) -> Bool {
+        guard let data = token.data(using: .utf8) else { return false }
+
+        let query = baseKeychainQuery()
+        let attributes = [kSecValueData: data] as CFDictionary
+        let updateStatus = SecItemUpdate(query, attributes)
+
+        switch updateStatus {
+        case errSecSuccess:
+            deleteLegacyToken()
+            return true
+        case errSecItemNotFound:
+            var item = baseKeychainAttributes()
+            item[kSecValueData] = data
+            let addStatus = SecItemAdd(item as CFDictionary, nil)
+            if addStatus == errSecSuccess {
+                deleteLegacyToken()
+                return true
+            }
+            return false
+        default:
+            return false
+        }
     }
 
     private func loadToken() -> String? {
-        guard let data = try? Data(contentsOf: Self.tokenFileURL) else { return nil }
+        if let token = loadTokenFromKeychain() {
+            return token
+        }
+
+        guard let legacyToken = loadLegacyToken() else { return nil }
+        if saveToken(legacyToken) {
+            return legacyToken
+        }
+        return legacyToken
+    }
+
+    private func deleteToken() {
+        SecItemDelete(baseKeychainQuery())
+        deleteLegacyToken()
+    }
+
+    private func loadTokenFromKeychain() -> String? {
+        var query = baseKeychainAttributes()
+        query[kSecReturnData] = true
+        query[kSecMatchLimit] = kSecMatchLimitOne
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess,
+              let data = item as? Data else {
+            return nil
+        }
+
         let token = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
         return token?.isEmpty == false ? token : nil
     }
 
-    private func deleteToken() {
-        try? FileManager.default.removeItem(at: Self.tokenFileURL)
+    private func loadLegacyToken() -> String? {
+        guard let data = try? Data(contentsOf: Self.legacyTokenFileURL) else { return nil }
+        let token = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return token?.isEmpty == false ? token : nil
+    }
+
+    private func deleteLegacyToken() {
+        try? FileManager.default.removeItem(at: Self.legacyTokenFileURL)
+    }
+
+    private func baseKeychainQuery() -> CFDictionary {
+        [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: Self.keychainService,
+            kSecAttrAccount: Self.keychainAccount,
+        ] as CFDictionary
+    }
+
+    private func baseKeychainAttributes() -> [CFString: Any] {
+        [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: Self.keychainService,
+            kSecAttrAccount: Self.keychainAccount,
+        ]
     }
 }
 


### PR DESCRIPTION
## Title

Harden OAuth token storage and fix extra usage currency display

## Summary

This PR improves the safety of local credential handling and fixes the extra usage price display.

## Changes

- Store the Anthropic OAuth access token in macOS Keychain instead of a plaintext file.
- Migrate existing installs from `~/.config/claude-usage-bar/token` into Keychain on next launch, then remove the legacy token file.
- Clear pending PKCE state when the OAuth flow is cancelled or fails to open the browser.
- Show a clear error if the token cannot be stored securely in Keychain.
- Keep the current OAuth scope unchanged and document why, to avoid breaking compatibility until Anthropic documents a narrower supported scope for the usage endpoint.
- Fix extra usage amounts by treating `used_credits` and `monthly_limit` as minor currency units and converting them to major units before display.
- Switch extra usage rendering to locale-aware currency formatting instead of a hard-coded `$`.
- Update the README to reflect Keychain storage and current security behavior.

## Why

### Token storage

The app previously stored the OAuth bearer token in `~/.config/claude-usage-bar/token` with `0600` permissions. That is better than default file permissions, but still weaker than using the macOS Keychain for a long-lived bearer token.

This change moves token storage to Keychain while preserving backward compatibility through one-time migration of the legacy token file.

### OAuth cleanup

The OAuth flow kept temporary PKCE state in memory but did not fully clear it on user cancellation. This change makes that cleanup explicit and also surfaces a browser-launch failure more clearly.

### Extra usage display

The API values for extra usage appear to be returned in minor units. The previous UI rendered them directly, which caused values like `2000 / 2000` to appear instead of `20.00 / 20.00`.

This change converts those values before rendering and formats them using the current locale.

## Testing

- Built the release binary successfully with SwiftPM.
- Repackaged and ad-hoc signed the `.app` bundle.
- Performed a launch sanity check on the rebuilt app bundle.
- Manually verified the extra usage display fix in code by converting `used_credits` and `monthly_limit` before formatting.

## Notes

- The OAuth scope is still `user:profile user:inference`. I did not narrow it in this PR because I could not confirm, from current primary-source Anthropic documentation, that the usage endpoint supports a smaller scope without breaking sign-in.
- This PR keeps the change surface intentionally small and focused on security hardening plus the extra usage formatting fix.
