### PR TITLE
Fix polling interval change to refresh immediately

### DIFF
--- a/Sources/ClaudeUsageBar/PopoverView.swift
+++ b/Sources/ClaudeUsageBar/PopoverView.swift
@@ -133,7 +133,7 @@ struct PopoverView: View {
             Menu {
                 ForEach(UsageService.pollingOptions, id: \.self) { mins in
                     Button {
-                        service.pollingMinutes = mins
+                        service.updatePollingInterval(mins)
                     } label: {
                         if mins == service.pollingMinutes {
                             Label(pollingOptionLabel(for: mins), systemImage: "checkmark")

--- a/Sources/ClaudeUsageBar/UsageService.swift
+++ b/Sources/ClaudeUsageBar/UsageService.swift
@@ -13,7 +13,7 @@ class UsageService: ObservableObject {
 
     var historyService: UsageHistoryService?
 
-    private var timer: AnyCancellable?
+    private var timer: Timer?
     private let usageEndpoint = URL(string: "https://api.anthropic.com/api/oauth/usage")!
     private var currentInterval: TimeInterval
 
@@ -21,11 +21,15 @@ class UsageService: ObservableObject {
     static let pollingOptions = [5, 15, 30, 60]
     nonisolated static let maxBackoffInterval: TimeInterval = 60 * 60
 
-    @Published var pollingMinutes: Int {
-        didSet {
-            UserDefaults.standard.set(pollingMinutes, forKey: "pollingMinutes")
-            currentInterval = TimeInterval(pollingMinutes * 60)
-            if isAuthenticated { scheduleTimer() }
+    @Published private(set) var pollingMinutes: Int
+
+    func updatePollingInterval(_ minutes: Int) {
+        pollingMinutes = minutes
+        UserDefaults.standard.set(minutes, forKey: "pollingMinutes")
+        currentInterval = TimeInterval(minutes * 60)
+        if isAuthenticated {
+            scheduleTimer()
+            Task { await fetchUsage() }
         }
     }
 
@@ -77,13 +81,15 @@ class UsageService: ObservableObject {
     }
 
     private func scheduleTimer() {
-        timer?.cancel()
-        timer = Timer.publish(every: currentInterval, on: .main, in: .common)
-            .autoconnect()
-            .sink { [weak self] _ in
+        timer?.invalidate()
+        let t = Timer(timeInterval: currentInterval, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated {
                 guard let self, self.isAuthenticated else { return }
                 Task { await self.fetchUsage() }
             }
+        }
+        RunLoop.main.add(t, forMode: .common)
+        timer = t
     }
 
     // MARK: - OAuth PKCE Flow


### PR DESCRIPTION
## Summary
- When the user changes the polling interval, trigger an immediate fetch so the UI updates right away instead of waiting up to N minutes for the next timer fire
- Replace `@Published pollingMinutes` didSet with explicit `updatePollingInterval()` method for clearer control flow
- Switch from Combine `Timer.publish` to `Foundation.Timer` for reliable timer replacement

## Test plan
- [ ] Change polling interval, observe immediate fetch + "Updated X ago" refreshing
- [ ] Verify periodic polling continues at the new interval
- [ ] `swift build` and `swift test` pass