### PR TITLE
Use Catmull-Rom interpolation for chart and tooltip

### DIFF
--- a/Sources/ClaudeUsageBar/UsageChartView.swift
+++ b/Sources/ClaudeUsageBar/UsageChartView.swift
@@ -40,7 +40,7 @@ struct UsageChartView: View {
                     y: .value("Usage", point.pct5h * 100)
                 )
                 .foregroundStyle(by: .value("Window", "5h"))
-                .interpolationMethod(.monotone)
+                .interpolationMethod(.catmullRom)
             }
 
             ForEach(points) { point in
@@ -49,7 +49,7 @@ struct UsageChartView: View {
                     y: .value("Usage", point.pct7d * 100)
                 )
                 .foregroundStyle(by: .value("Window", "7d"))
-                .interpolationMethod(.monotone)
+                .interpolationMethod(.catmullRom)
             }
 
             if let iv = interpolated {
@@ -156,28 +156,45 @@ struct UsageChartView: View {
         let pct7d: Double
     }
 
+    private func catmullRom(_ p0: Double, _ p1: Double, _ p2: Double, _ p3: Double, t: Double) -> Double {
+        let t2 = t * t
+        let t3 = t2 * t
+        return 0.5 * (
+            (2 * p1) +
+            (-p0 + p2) * t +
+            (2 * p0 - 5 * p1 + 4 * p2 - p3) * t2 +
+            (-p0 + 3 * p1 - 3 * p2 + p3) * t3
+        )
+    }
+
     private func interpolateValues(at date: Date, in points: [UsageDataPoint]) -> InterpolatedValues? {
-        guard !points.isEmpty else { return nil }
+        guard points.count >= 2 else { return nil }
 
         let sorted = points.sorted { $0.timestamp < $1.timestamp }
 
-        // Outside data range — show zeros
         if date < sorted.first!.timestamp || date > sorted.last!.timestamp {
             return InterpolatedValues(date: date, pct5h: 0, pct7d: 0)
         }
 
-        // Find surrounding points and lerp
         for i in 0..<(sorted.count - 1) {
-            let a = sorted[i]
-            let b = sorted[i + 1]
-            if date >= a.timestamp && date <= b.timestamp {
-                let span = b.timestamp.timeIntervalSince(a.timestamp)
-                let t = span > 0 ? date.timeIntervalSince(a.timestamp) / span : 0
-                return InterpolatedValues(
-                    date: date,
-                    pct5h: a.pct5h + (b.pct5h - a.pct5h) * t,
-                    pct7d: a.pct7d + (b.pct7d - a.pct7d) * t
+            if date >= sorted[i].timestamp && date <= sorted[i + 1].timestamp {
+                let span = sorted[i + 1].timestamp.timeIntervalSince(sorted[i].timestamp)
+                let t = span > 0 ? date.timeIntervalSince(sorted[i].timestamp) / span : 0
+
+                // Four control points, clamping at boundaries
+                let i0 = max(0, i - 1)
+                let i3 = min(sorted.count - 1, i + 2)
+
+                let pct5h = catmullRom(
+                    sorted[i0].pct5h, sorted[i].pct5h,
+                    sorted[i + 1].pct5h, sorted[i3].pct5h, t: t
                 )
+                let pct7d = catmullRom(
+                    sorted[i0].pct7d, sorted[i].pct7d,
+                    sorted[i + 1].pct7d, sorted[i3].pct7d, t: t
+                )
+
+                return InterpolatedValues(date: date, pct5h: pct5h, pct7d: pct7d)
             }
         }
 


### PR DESCRIPTION
## Summary
- Switch chart line interpolation from `.monotone` to `.catmullRom` for smoother curves
- Replace linear lerp tooltip interpolation with a matching Catmull-Rom spline so crosshair values track the rendered curve exactly

## Test plan
- [ ] Hover over chart, verify tooltip percentages follow the curve smoothly
- [ ] Verify chart lines render without visual artifacts
- [ ] `swift build` and `swift test` pass