### PR TITLE
feat: show per-model breakdown as segmented bar in 7-day window

### DIFF
--- a/Sources/ClaudeUsageBar/PopoverView.swift
+++ b/Sources/ClaudeUsageBar/PopoverView.swift
@@ -6,6 +6,25 @@ struct PopoverView: View {
     @ObservedObject var historyService: UsageHistoryService
     @AppStorage("launchAtLoginAsked") private var launchAtLoginAsked = false
     @State private var showLaunchPrompt = false
+    @State private var isDetailMode = false
+
+    /// Segments derived from the API's per-model 7-day buckets.
+    /// Returns nil when per-model data isn't available yet.
+    private var sevenDaySegments: [SegmentedProgressView.Segment]? {
+        guard let total = service.usage?.sevenDay?.utilization, total > 0 else { return nil }
+        var segs: [SegmentedProgressView.Segment] = []
+        if let pct = service.usage?.sevenDaySonnet?.utilization, pct > 0 {
+            segs.append(.init(label: "Sonnet", color: .teal, fraction: pct / total))
+        }
+        if let pct = service.usage?.sevenDayOpus?.utilization, pct > 0 {
+            segs.append(.init(label: "Opus", color: .purple, fraction: pct / total))
+        }
+        let accounted = segs.reduce(0) { $0 + $1.fraction }
+        if accounted < 0.99 {
+            segs.append(.init(label: "Other", color: .secondary, fraction: 1.0 - accounted))
+        }
+        return segs.isEmpty ? nil : segs
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -79,20 +98,13 @@ struct PopoverView: View {
 
         UsageBucketRow(
             label: "7-Day Window",
-            bucket: service.usage?.sevenDay
+            bucket: service.usage?.sevenDay,
+            segments: isDetailMode ? sevenDaySegments : nil
         )
-
-        if let opus = service.usage?.sevenDayOpus,
-           opus.utilization != nil {
-            Divider()
-            Text("Per-Model (7 day)")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-            UsageBucketRow(label: "Opus", bucket: opus)
-            if let sonnet = service.usage?.sevenDaySonnet {
-                UsageBucketRow(label: "Sonnet", bucket: sonnet)
-            }
-        }
+        .simultaneousGesture(TapGesture().onEnded {
+            guard NSEvent.modifierFlags.contains(.option) else { return }
+            isDetailMode.toggle()
+        })
 
         if let extra = service.usage?.extraUsage, extra.isEnabled {
             Divider()
@@ -189,6 +201,7 @@ private struct CodeEntryView: View {
 private struct UsageBucketRow: View {
     let label: String
     let bucket: UsageBucket?
+    var segments: [SegmentedProgressView.Segment]? = nil
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -200,8 +213,15 @@ private struct UsageBucketRow: View {
                     .font(.subheadline)
                     .monospacedDigit()
             }
-            ProgressView(value: (bucket?.utilization ?? 0) / 100.0, total: 1.0)
-                .tint(colorForPct((bucket?.utilization ?? 0) / 100.0))
+            if let segs = segments {
+                SegmentedProgressView(
+                    fillFraction: (bucket?.utilization ?? 0) / 100.0,
+                    segments: segs
+                )
+            } else {
+                ProgressView(value: (bucket?.utilization ?? 0) / 100.0, total: 1.0)
+                    .tint(colorForPct((bucket?.utilization ?? 0) / 100.0))
+            }
             if let resetDate = bucket?.resetsAtDate {
                 Text("Resets \(resetDate, style: .relative)")
                     .font(.caption2)

--- a/Sources/ClaudeUsageBar/SegmentedProgressView.swift
+++ b/Sources/ClaudeUsageBar/SegmentedProgressView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+/// A segmented progress bar that fills to `fillFraction` and subdivides that fill
+/// proportionally by model family. Hover over a segment to see a tooltip.
+struct SegmentedProgressView: View {
+
+    struct Segment: Equatable {
+        let label: String
+        let color: Color
+        /// This segment's share of the filled region (fractions sum to 1.0).
+        let fraction: Double
+    }
+
+    /// Overall fill fraction 0–1 (e.g. 0.54 for 54% utilization).
+    let fillFraction: Double
+    let segments: [Segment]
+
+    @State private var hoveredSegment: Segment? = nil
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                // Background track
+                Capsule()
+                    .fill(Color.secondary.opacity(0.2))
+
+                // Filled segments, clipped to a capsule so edges are rounded
+                HStack(spacing: 0) {
+                    ForEach(Array(segments.enumerated()), id: \.offset) { _, seg in
+                        Rectangle()
+                            .fill(seg.color.opacity(hoveredSegment == seg ? 1.0 : 0.8))
+                            .frame(width: max(0, geo.size.width * fillFraction * seg.fraction))
+                            .onHover { isHovered in
+                                withAnimation(.easeInOut(duration: 0.12)) {
+                                    hoveredSegment = isHovered ? seg : nil
+                                }
+                            }
+                    }
+                }
+                .clipShape(Capsule())
+            }
+        }
+        .frame(height: 8)
+        .overlay(alignment: .topTrailing) {
+            if let seg = hoveredSegment {
+                Text("\(seg.label) · \(Int(round(fillFraction * seg.fraction * 100)))%")
+                    .font(.caption2)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 3)
+                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 4))
+                    .offset(y: -20)
+                    .transition(.opacity)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The current UI displays Opus and Sonnet as **separate rows below a divider**, disconnected from the bar they describe. This PR consolidates that same information into the bar itself — cleaner and more compact.

**Before:** flat bar + separate "Per-Model (7 day)" section with individual Opus/Sonnet rows

**After:** the 7-day bar subdivides its fill by model family; the separate section is removed

## How it works

- **Option+click** the 7-Day Window row to toggle detail mode on/off
- In detail mode the bar segments are proportional to each model's share of the total utilization, using the values already returned by the API (`seven_day_opus.utilization / seven_day.utilization`)
- Hover over any segment to see a tooltip: e.g. `Sonnet · 38%`
- Colors: Sonnet = teal, Opus = purple, Other = gray
- Falls back to the existing plain `ProgressView` when per-model data is unavailable — no behaviour change for unauthenticated users or when the API doesn't return model breakdowns

## Changes

- **New file:** `SegmentedProgressView.swift` — a fill-capped segmented bar with hover tooltips; self-contained, no dependencies on other new code
- **`PopoverView.swift`:**
  - Add `@State private var isDetailMode`
  - Add `sevenDaySegments` computed property (derives fractions from existing API data)
  - Add `simultaneousGesture` on the 7-day row for Option+click toggle
  - Extend `UsageBucketRow` with an optional `segments` parameter (default `nil`, fully backwards-compatible)
  - Remove the now-redundant "Per-Model (7 day)" divider + row section

No data layer changes. No new API calls. No new dependencies.