### PR TITLE
fix: strip extended attributes before codesigning in build.sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -37,6 +37,13 @@ actool --compile "$APP_BUNDLE/Contents/Resources" \
        --output-partial-info-plist /dev/null \
        "$PROJECT_DIR/Resources/Assets.xcassets" > /dev/null
 
+# --- Strip extended attributes before codesigning ---
+# actool and ditto can leave resource forks / Finder metadata that cause
+# codesign to fail with "resource fork, Finder information, or similar
+# detritus not allowed". Stripping them first makes the step reliable
+# across all environments.
+xattr -cr "$APP_BUNDLE"
+
 # --- Ad-hoc codesign ---
 echo "==> Codesigning (ad-hoc)..."
 codesign --force --sign - "$APP_BUNDLE"


### PR DESCRIPTION
## Problem

`make app` (and `make zip`) fails with:

```
ClaudeUsageBar.app: resource fork, Finder information, or similar detritus not allowed
```

This happens because `actool` and/or `ditto` can leave extended attributes (resource forks, Finder metadata, quarantine flags) on bundle files. `codesign` treats any such attributes as an error and refuses to sign.

Reproduces reliably when:
- Building on top of a bundle directory that was previously downloaded from the internet
- Running the build script more than once on the same output directory
- Building on macOS 15+

## Fix

Add `xattr -cr "$APP_BUNDLE"` immediately before the `codesign` step. This strips all extended attributes from the bundle tree and is the standard fix recommended in Apple's documentation and developer forums.

**One line change to `scripts/build.sh`.**

## Verification

```bash
make app   # previously failed; now succeeds cleanly
make zip   # end-to-end release build succeeds
```