### PR TITLE
feat: right-click menu bar icon to quit

### DIFF
--- a/Sources/ClaudeUsageBar/ClaudeUsageBarApp.swift
+++ b/Sources/ClaudeUsageBar/ClaudeUsageBarApp.swift
@@ -9,9 +9,10 @@ struct ClaudeUsageBarApp: App {
         MenuBarExtra {
             PopoverView(service: service, historyService: historyService)
         } label: {
-            Image(nsImage: service.isAuthenticated
-                ? renderIcon(pct5h: service.pct5h, pct7d: service.pct7d)
-                : renderUnauthenticatedIcon()
+            RightClickableMenuBarLabel(
+                image: service.isAuthenticated
+                    ? renderIcon(pct5h: service.pct5h, pct7d: service.pct7d)
+                    : renderUnauthenticatedIcon()
             )
                 .task {
                     historyService.loadHistory()

--- a/Sources/ClaudeUsageBar/RightClickableMenuBarLabel.swift
+++ b/Sources/ClaudeUsageBar/RightClickableMenuBarLabel.swift
@@ -1,0 +1,39 @@
+import AppKit
+import SwiftUI
+
+/// Wraps the menu bar icon in an NSView so right-click can be intercepted.
+/// A left-click still opens the MenuBarExtra window as normal.
+/// A right-click shows a minimal context menu with a Quit action.
+struct RightClickableMenuBarLabel: NSViewRepresentable {
+    let image: NSImage
+
+    func makeNSView(context: Context) -> MenuBarIconView {
+        MenuBarIconView()
+    }
+
+    func updateNSView(_ nsView: MenuBarIconView, context: Context) {
+        nsView.image = image
+    }
+
+    final class MenuBarIconView: NSView {
+        var image: NSImage? { didSet { needsDisplay = true } }
+
+        override var intrinsicContentSize: NSSize {
+            image?.size ?? NSSize(width: 22, height: 18)
+        }
+
+        override func draw(_ dirtyRect: NSRect) {
+            image?.draw(in: bounds, from: .zero, operation: .sourceOver, fraction: 1)
+        }
+
+        override func rightMouseDown(with event: NSEvent) {
+            let menu = NSMenu()
+            menu.addItem(NSMenuItem(
+                title: "Quit Claude Usage Bar",
+                action: #selector(NSApplication.terminate(_:)),
+                keyEquivalent: "q"
+            ))
+            NSMenu.popUpContextMenu(menu, with: event, for: self)
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The only way to quit Claude Usage Bar is to open the popover and click the **Quit** button inside. This is non-standard — on macOS, right/secondary-clicking a menu bar icon is the conventional way to access utility actions like Quit without having to open the full UI.

## Solution

Add `RightClickableMenuBarLabel` — a small `NSViewRepresentable` that renders the existing icon identically but overrides `rightMouseDown` to show a one-item context menu:

```
Quit Claude Usage Bar  ⌘Q
```

**Left-click is completely unchanged.** `MenuBarExtra` still opens its popover window as before.

## Implementation

`MenuBarExtra`'s label is a SwiftUI view, and SwiftUI has no native right-click event API. The standard solution is an `NSViewRepresentable` wrapper:

- **New file:** `RightClickableMenuBarLabel.swift` — 40 lines. Wraps `NSImage` rendering in an `NSView` subclass, overrides `rightMouseDown(with:)` to call `NSMenu.popUpContextMenu`.
- **`ClaudeUsageBarApp.swift`:** Replace `Image(nsImage:)` with `RightClickableMenuBarLabel(image:)` — a 3-line diff.

No changes to `PopoverView`, `UsageService`, or any other file.