### PR TITLE
Remove Launch at Login toggle from popover

### DIFF
--- a/Sources/ClaudeUsageBar/PopoverView.swift
+++ b/Sources/ClaudeUsageBar/PopoverView.swift
@@ -1,11 +1,8 @@
 import SwiftUI
-import ServiceManagement
 
 struct PopoverView: View {
     @ObservedObject var service: UsageService
     @ObservedObject var historyService: UsageHistoryService
-    @AppStorage("launchAtLoginAsked") private var launchAtLoginAsked = false
-    @State private var showLaunchPrompt = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -20,22 +17,6 @@ struct PopoverView: View {
         }
         .padding()
         .frame(width: 340)
-        .onAppear {
-            if !launchAtLoginAsked {
-                showLaunchPrompt = true
-            }
-        }
-        .alert("Launch at Login?", isPresented: $showLaunchPrompt) {
-            Button("Enable") {
-                setLaunchAtLogin(true)
-                launchAtLoginAsked = true
-            }
-            Button("No Thanks", role: .cancel) {
-                launchAtLoginAsked = true
-            }
-        } message: {
-            Text("Would you like Claude Usage Bar to start automatically when you log in?")
-        }
     }
 
     @ViewBuilder
@@ -133,14 +114,6 @@ struct PopoverView: View {
                 .foregroundStyle(.secondary)
         }
 
-        Toggle("Launch at Login", isOn: Binding(
-            get: { SMAppService.mainApp.status == .enabled },
-            set: { setLaunchAtLogin($0) }
-        ))
-        .toggleStyle(.switch)
-        .controlSize(.mini)
-        .font(.caption)
-        .foregroundStyle(.secondary)
     }
 }
 
@@ -239,18 +212,6 @@ private struct ExtraUsageRow: View {
                     .tint(.blue)
             }
         }
-    }
-}
-
-private func setLaunchAtLogin(_ enabled: Bool) {
-    do {
-        if enabled {
-            try SMAppService.mainApp.register()
-        } else {
-            try SMAppService.mainApp.unregister()
-        }
-    } catch {
-        // Silently ignore — user can toggle again
     }
 }
 


### PR DESCRIPTION
## Summary

- Removes the Launch at Login toggle and its first-launch alert from the popover dashboard
- Removes `import ServiceManagement`, `@AppStorage("launchAtLoginAsked")`, the `@State` flag, `.onAppear` prompt trigger, `.alert` block, the `Toggle` in `usageView`, and the `setLaunchAtLogin` helper

## Motivation

Launch at Login is system-level configuration that users already manage in **System Settings → General → Login Items**. Surfacing it inside the usage dashboard adds visual noise to a focused, information-dense UI. Removing it keeps the popover clean and defers this preference to the OS-native location where users expect to find it.

## Test plan

- [ ] Build succeeds (`swift build`)
- [ ] Popover no longer shows a Launch at Login toggle
- [ ] No first-launch alert about Launch at Login on first open
- [ ] Launch at login can still be configured via System Settings → General → Login Items

🤖 Generated with [Claude Code](https://claude.com/claude-code)