### PR TITLE
Fix crash on launch caused by Bundle.module fatalError

### DIFF
--- a/Sources/ClaudeUsageBar/MenuBarIconRenderer.swift
+++ b/Sources/ClaudeUsageBar/MenuBarIconRenderer.swift
@@ -110,8 +110,27 @@ private func drawDashedBar(x: CGFloat, y: CGFloat, width: CGFloat, height: CGFlo
 // MARK: - Claude logo (pre-rendered 512px template PNG)
 
 private let claudeLogoImage: NSImage? = {
-    guard let url = Bundle.module.url(forResource: "claude-logo", withExtension: "png") else { return nil }
-    return NSImage(contentsOf: url)
+    // SwiftPM's generated Bundle.module accessor calls fatalError when the
+    // resource bundle isn't next to the executable — which is the case inside
+    // a standard .app bundle (resources live in Contents/Resources/).
+    // Search the likely locations ourselves to avoid the crash.
+    let bundleName = "ClaudeUsageBar_ClaudeUsageBar"
+    let candidates: [URL?] = [
+        // .app bundle: Contents/Resources/<bundle>
+        Bundle.main.url(forResource: bundleName, withExtension: "bundle"),
+        // Next to the executable (SwiftPM development builds)
+        Bundle.main.executableURL?
+            .deletingLastPathComponent()
+            .appendingPathComponent(bundleName + ".bundle"),
+    ]
+
+    for case let url? in candidates {
+        if let bundle = Bundle(url: url),
+           let png = bundle.url(forResource: "claude-logo", withExtension: "png") {
+            return NSImage(contentsOf: png)
+        }
+    }
+    return nil
 }()
 
 private func drawClaudeLogo(x: CGFloat, y: CGFloat, size: CGFloat) {


### PR DESCRIPTION
## Summary

Fixes #18 — v0.0.4 crashes immediately on launch with:
```
Fatal error: could not load resource bundle: from .../ClaudeUsageBar.app/ClaudeUsageBar_ClaudeUsageBar.bundle
```

SwiftPM's generated `Bundle.module` accessor looks for the resource bundle next to the executable and calls `fatalError` if it's not found. In the packaged `.app` bundle, the resource bundle lives in `Contents/Resources/`, not next to the binary in `Contents/MacOS/`, so the lookup always fails.

This replaces `Bundle.module` with a manual lookup that checks both the `.app` resources directory and the executable-sibling path (for development builds), returning `nil` gracefully instead of crashing.

## Test plan
- [x] `make app && ./ClaudeUsageBar.app/Contents/MacOS/ClaudeUsageBar` launches without crash
- [x] Verified against the v0.0.4 release zip — original binary crashes, patched binary works
- [ ] Logo renders correctly in menu bar