### PR TITLE
Verify release archives before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Build release archive
         env:
           REPOSITORY_NAME: ${{ github.event.repository.name }}
+          EXPECT_FEED_URL: '1'
         run: |
           version="${GITHUB_REF_NAME#v}"
           owner="$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,8 @@ Sources/ClaudeUsageBar/
 |---------|-------------|
 | `make build` | Release build via `swift build` |
 | `make app` | Build + create `.app` bundle |
-| `make zip` | Build + bundle + zip for distribution |
+| `make zip` | Build + bundle + zip, then verify the release artifact |
+| `make verify-release` | Inspect the packaged zip artifact for required resources/frameworks |
 | `make install` | Build + install to `/Applications` |
 | `make clean` | Remove build artifacts |
 
@@ -47,6 +48,7 @@ Sources/ClaudeUsageBar/
 Releases are tag-driven. Pushing a `v*` tag triggers the GitHub Actions workflow that:
 
 - builds the release zip once
+- verifies the extracted zip contains the expected app bundle resources before publishing
 - uploads that exact zip to the GitHub Release
 - reuses GitHub-generated release notes for both the release body and the Sparkle update entry
 - generates a signed Sparkle appcast from that zip

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build app zip install clean
+.PHONY: build app zip verify-release install clean
 
 build:
 	cd macos && swift build -c release
@@ -8,6 +8,10 @@ app:
 
 zip:
 	bash macos/scripts/build.sh --zip
+	bash macos/scripts/verify-release.sh macos/ClaudeUsageBar.zip
+
+verify-release:
+	bash macos/scripts/verify-release.sh
 
 install: app
 	rm -rf /Applications/ClaudeUsageBar.app

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ History is buffered in memory and flushed to disk every 5 minutes and on app qui
 ```sh
 make build          # release build only
 make app            # build + create .app bundle
-make zip            # build + bundle + zip for distribution
+make zip            # build + bundle + zip + verify distribution artifact
+make verify-release # inspect the packaged zip artifact
 make install        # build + install to /Applications
 make clean          # remove build artifacts
 ```
@@ -89,6 +90,7 @@ make clean          # remove build artifacts
 This repo now uses a tag-driven release flow. Pushing a `v*` tag will:
 
 - build `ClaudeUsageBar.zip`
+- verify the extracted zip contains the expected app bundle resources and updater framework
 - create the GitHub Release
 - reuse GitHub-generated release notes for both the GitHub Release and the Sparkle update entry
 - generate a signed Sparkle `appcast.xml` from that exact zip

--- a/macos/scripts/verify-release.sh
+++ b/macos/scripts/verify-release.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+APP_NAME="ClaudeUsageBar"
+ZIP_PATH="${1:-$PROJECT_DIR/$APP_NAME.zip}"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/claude-usage-bar-release.XXXXXX")"
+
+cleanup() {
+    rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+if [[ ! -f "$ZIP_PATH" ]]; then
+    echo "Error: release archive not found at $ZIP_PATH"
+    exit 1
+fi
+
+APP_BUNDLE="$TMP_DIR/$APP_NAME.app"
+APP_PLIST="$APP_BUNDLE/Contents/Info.plist"
+RESOURCE_BUNDLE="$APP_BUNDLE/Contents/Resources/${APP_NAME}_${APP_NAME}.bundle"
+SPARKLE_FRAMEWORK="$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"
+
+echo "==> Extracting $(basename "$ZIP_PATH")..."
+ditto -x -k "$ZIP_PATH" "$TMP_DIR"
+
+if [[ ! -d "$APP_BUNDLE" ]]; then
+    echo "Error: extracted archive did not contain $APP_NAME.app"
+    exit 1
+fi
+
+echo "==> Verifying packaged resources..."
+[[ -f "$APP_PLIST" ]] || { echo "Error: missing Info.plist"; exit 1; }
+[[ -d "$RESOURCE_BUNDLE" ]] || { echo "Error: missing SwiftPM resource bundle"; exit 1; }
+[[ -f "$RESOURCE_BUNDLE/Info.plist" ]] || { echo "Error: missing resource bundle Info.plist"; exit 1; }
+[[ -f "$RESOURCE_BUNDLE/claude-logo.png" ]] || { echo "Error: missing packaged logo resource"; exit 1; }
+[[ -f "$RESOURCE_BUNDLE/en.lproj/Localizable.strings" ]] || { echo "Error: missing packaged localization resource"; exit 1; }
+[[ -d "$SPARKLE_FRAMEWORK" ]] || { echo "Error: missing Sparkle.framework"; exit 1; }
+
+echo "==> Verifying app signature..."
+codesign -v "$APP_BUNDLE"
+
+echo "==> Verifying updater metadata..."
+plutil -extract SUPublicEDKey raw "$APP_PLIST" >/dev/null
+
+if [[ "${EXPECT_FEED_URL:-0}" == "1" ]]; then
+    plutil -extract SUFeedURL raw "$APP_PLIST" >/dev/null
+fi
+
+echo "==> Release archive looks good"


### PR DESCRIPTION
## Summary
- add a packaged-zip verification script for the macOS release artifact
- make `make zip` validate the generated archive by default
- have the release workflow enforce the feed URL and run through the same zip verification path

## Verification
- make zip
- EXPECT_FEED_URL=1 SU_FEED_URL=https://example.com/appcast.xml make zip