### PR TITLE
Fix local profile loader actor isolation

### DIFF
--- a/macos/Sources/ClaudeUsageBar/UsageService.swift
+++ b/macos/Sources/ClaudeUsageBar/UsageService.swift
@@ -317,7 +317,7 @@ class UsageService: ObservableObject {
     }
 
     /// Try reading the email from Claude Code's local config as a fallback.
-    private static func loadLocalProfile() -> String? {
+    nonisolated private static func loadLocalProfile() -> String? {
         let url = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".claude.json")
         guard let data = try? Data(contentsOf: url),


### PR DESCRIPTION
## Summary
- mark `UsageService.loadLocalProfile()` as `nonisolated`
- fix the Swift compiler error introduced after merging #27

## Verification
- `swift build` in `macos`
- `swift test` in `macos`