### PR TITLE
Harden release artifacts and add DMG distribution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,20 @@ jobs:
       - name: Run tests
         run: cd macos && swift test
 
-      - name: Build app archive
-        run: make zip
+      - name: Build app bundle
+        run: make app
 
-      - name: Upload artifact
+      - name: Package app archives
+        run: make release-artifacts
+
+      - name: Upload ZIP artifact
         uses: actions/upload-artifact@v4
         with:
           name: ClaudeUsageBar.zip
           path: macos/ClaudeUsageBar.zip
+
+      - name: Upload DMG artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ClaudeUsageBar.dmg
+          path: macos/ClaudeUsageBar.dmg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,22 +13,26 @@ jobs:
     runs-on: macos-14
     permissions:
       contents: write
+    env:
+      REPOSITORY_NAME: ${{ github.event.repository.name }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5
 
-      - name: Build release archive
-        env:
-          REPOSITORY_NAME: ${{ github.event.repository.name }}
-          EXPECT_FEED_URL: '1'
+      - name: Build release app bundle
         run: |
           version="${GITHUB_REF_NAME#v}"
           owner="$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')"
           export APP_VERSION="$version"
           export SU_FEED_URL="https://${owner}.github.io/${REPOSITORY_NAME}/appcast.xml"
-          make zip
+          make app
+
+      - name: Package and verify release artifacts
+        env:
+          EXPECT_FEED_URL: '1'
+        run: make release-artifacts
 
       - name: Generate release notes
         env:
@@ -74,7 +78,9 @@ jobs:
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
-          files: macos/ClaudeUsageBar.zip
+          files: |
+            macos/ClaudeUsageBar.zip
+            macos/ClaudeUsageBar.dmg
           body_path: dist/release-notes.md
 
       - name: Generate Sparkle appcast

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,9 @@ Sources/ClaudeUsageBar/
 | `make build` | Release build via `swift build` |
 | `make app` | Build + create `.app` bundle |
 | `make zip` | Build + bundle + zip, then verify the release artifact |
-| `make verify-release` | Inspect the packaged zip artifact for required resources/frameworks |
+| `make dmg` | Build + bundle + drag-to-Applications disk image, then verify it |
+| `make release-artifacts` | Build once, then create and verify both ZIP and DMG artifacts |
+| `make verify-release` | Inspect the packaged ZIP and DMG artifacts for required resources/frameworks |
 | `make install` | Build + install to `/Applications` |
 | `make clean` | Remove build artifacts |
 
@@ -47,9 +49,10 @@ Sources/ClaudeUsageBar/
 
 Releases are tag-driven. Pushing a `v*` tag triggers the GitHub Actions workflow that:
 
-- builds the release zip once
-- verifies the extracted zip contains the expected app bundle resources before publishing
-- uploads that exact zip to the GitHub Release
+- builds the release app bundle once
+- produces both a ZIP (for Sparkle) and a DMG (for manual drag-to-Applications installs)
+- verifies the packaged artifacts before publishing
+- uploads those exact artifacts to the GitHub Release
 - reuses GitHub-generated release notes for both the release body and the Sparkle update entry
 - generates a signed Sparkle appcast from that zip
 - deploys the appcast to GitHub Pages

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build app zip verify-release install clean
+.PHONY: build app zip dmg release-artifacts verify-release install clean
 
 build:
 	cd macos && swift build -c release
@@ -10,8 +10,18 @@ zip:
 	bash macos/scripts/build.sh --zip
 	bash macos/scripts/verify-release.sh macos/ClaudeUsageBar.zip
 
+dmg:
+	bash macos/scripts/build.sh --dmg
+	bash macos/scripts/verify-release.sh macos/ClaudeUsageBar.dmg
+
+release-artifacts:
+	bash macos/scripts/build.sh --skip-build --zip --dmg
+	bash macos/scripts/verify-release.sh macos/ClaudeUsageBar.zip
+	bash macos/scripts/verify-release.sh macos/ClaudeUsageBar.dmg
+
 verify-release:
-	bash macos/scripts/verify-release.sh
+	bash macos/scripts/verify-release.sh macos/ClaudeUsageBar.zip
+	if [ -f macos/ClaudeUsageBar.dmg ]; then bash macos/scripts/verify-release.sh macos/ClaudeUsageBar.dmg; fi
 
 install: app
 	rm -rf /Applications/ClaudeUsageBar.app
@@ -19,4 +29,4 @@ install: app
 
 clean:
 	cd macos && swift package clean
-	rm -rf macos/ClaudeUsageBar.app macos/ClaudeUsageBar.zip
+	rm -rf macos/ClaudeUsageBar.app macos/ClaudeUsageBar.zip macos/ClaudeUsageBar.dmg

--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ A tiny macOS menu bar app that shows your Claude API usage at a glance. Click it
 
 ### Download
 
-1. Download `ClaudeUsageBar.zip` from the [latest release](https://github.com/Blimp-Labs/claude-usage-bar/releases/latest)
-2. Extract and drag `ClaudeUsageBar.app` to `/Applications`
-3. On first launch: right-click the app → **Open** (required for ad-hoc signed apps)
+1. Download `ClaudeUsageBar.dmg` from the [latest release](https://github.com/Blimp-Labs/claude-usage-bar/releases/latest)
+2. Open the disk image and drag `ClaudeUsageBar.app` into `Applications`
+3. Launch the app from `/Applications`
+4. macOS may require right-click → **Open** on first launch
 
 ### Build from source
 
@@ -46,6 +47,7 @@ Requires Xcode 15+ / Swift 5.9+ and macOS 14 (Sonoma) or later.
 git clone https://github.com/Blimp-Labs/claude-usage-bar.git
 cd claude-usage-bar
 make app            # build .app bundle
+make dmg            # build drag-to-Applications disk image
 make install        # copy to /Applications
 ```
 
@@ -80,7 +82,9 @@ History is buffered in memory and flushed to disk every 5 minutes and on app qui
 make build          # release build only
 make app            # build + create .app bundle
 make zip            # build + bundle + zip + verify distribution artifact
-make verify-release # inspect the packaged zip artifact
+make dmg            # build + bundle + DMG + verify distribution artifact
+make release-artifacts  # build once, then create and verify both ZIP and DMG
+make verify-release # inspect the packaged ZIP and DMG artifacts
 make install        # build + install to /Applications
 make clean          # remove build artifacts
 ```
@@ -89,8 +93,9 @@ make clean          # remove build artifacts
 
 This repo now uses a tag-driven release flow. Pushing a `v*` tag will:
 
-- build `ClaudeUsageBar.zip`
-- verify the extracted zip contains the expected app bundle resources and updater framework
+- build the `.app` bundle once
+- produce `ClaudeUsageBar.zip` for Sparkle and `ClaudeUsageBar.dmg` for manual installs
+- verify the packaged artifacts contain the expected app bundle resources and updater framework
 - create the GitHub Release
 - reuse GitHub-generated release notes for both the GitHub Release and the Sparkle update entry
 - generate a signed Sparkle `appcast.xml` from that exact zip
@@ -109,6 +114,8 @@ One-time repo setup:
 2. Add a repository Actions secret named `SPARKLE_PRIVATE_KEY`.
 
 Local source builds intentionally ship with Sparkle disabled unless `SU_FEED_URL` is injected during packaging. This prevents forks and local builds from auto-updating to upstream binaries.
+
+Manual installs should prefer the DMG. The ZIP remains the source of truth for Sparkle updates and appcast generation.
 
 You can export the current Sparkle private key from your local Keychain with:
 

--- a/macos/scripts/build.sh
+++ b/macos/scripts/build.sh
@@ -6,10 +6,34 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 APP_NAME="ClaudeUsageBar"
 BUILD_DIR="$PROJECT_DIR/.build"
 APP_BUNDLE="$PROJECT_DIR/$APP_NAME.app"
+ZIP_PATH="$PROJECT_DIR/$APP_NAME.zip"
+DMG_PATH="$PROJECT_DIR/$APP_NAME.dmg"
 PLIST_BUDDY="/usr/libexec/PlistBuddy"
 PLUTIL="/usr/bin/plutil"
+CREATE_ZIP=0
+CREATE_DMG=0
+SKIP_BUILD=0
 
 cd "$PROJECT_DIR"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --zip)
+            CREATE_ZIP=1
+            ;;
+        --dmg)
+            CREATE_DMG=1
+            ;;
+        --skip-build)
+            SKIP_BUILD=1
+            ;;
+        *)
+            echo "Error: unknown option '$1'"
+            exit 1
+            ;;
+    esac
+    shift
+done
 
 version_to_build_number() {
     local version="$1"
@@ -28,87 +52,123 @@ version_to_build_number() {
     printf '%s' "$version"
 }
 
-# --- Build release binary ---
-echo "==> Building release binary..."
-swift build -c release
+build_app_bundle() {
+    echo "==> Building release binary..."
+    swift build -c release
 
-BINARY="$BUILD_DIR/release/$APP_NAME"
-if [[ ! -f "$BINARY" ]]; then
-    echo "Error: binary not found at $BINARY"
-    exit 1
-fi
+    local binary="$BUILD_DIR/release/$APP_NAME"
+    if [[ ! -f "$binary" ]]; then
+        echo "Error: binary not found at $binary"
+        exit 1
+    fi
 
-# --- Create .app bundle ---
-echo "==> Creating $APP_NAME.app bundle..."
-rm -rf "$APP_BUNDLE"
-mkdir -p "$APP_BUNDLE/Contents/MacOS"
-mkdir -p "$APP_BUNDLE/Contents/Resources"
+    echo "==> Creating $APP_NAME.app bundle..."
+    rm -rf "$APP_BUNDLE"
+    mkdir -p "$APP_BUNDLE/Contents/MacOS"
+    mkdir -p "$APP_BUNDLE/Contents/Resources"
 
-cp "$PROJECT_DIR/Resources/Info.plist" "$APP_BUNDLE/Contents/Info.plist"
-cp "$BINARY" "$APP_BUNDLE/Contents/MacOS/$APP_NAME"
+    cp "$PROJECT_DIR/Resources/Info.plist" "$APP_BUNDLE/Contents/Info.plist"
+    cp "$binary" "$APP_BUNDLE/Contents/MacOS/$APP_NAME"
 
-APP_VERSION="${APP_VERSION:-$($PLIST_BUDDY -c 'Print :CFBundleShortVersionString' "$PROJECT_DIR/Resources/Info.plist")}"
-APP_BUILD="${APP_BUILD:-$(version_to_build_number "$APP_VERSION")}"
+    local app_version="${APP_VERSION:-$($PLIST_BUDDY -c 'Print :CFBundleShortVersionString' "$PROJECT_DIR/Resources/Info.plist")}"
+    local app_build="${APP_BUILD:-$(version_to_build_number "$app_version")}"
 
-"$PLIST_BUDDY" -c "Set :CFBundleShortVersionString $APP_VERSION" "$APP_BUNDLE/Contents/Info.plist"
-"$PLIST_BUDDY" -c "Set :CFBundleVersion $APP_BUILD" "$APP_BUNDLE/Contents/Info.plist"
+    "$PLIST_BUDDY" -c "Set :CFBundleShortVersionString $app_version" "$APP_BUNDLE/Contents/Info.plist"
+    "$PLIST_BUDDY" -c "Set :CFBundleVersion $app_build" "$APP_BUNDLE/Contents/Info.plist"
 
-if [[ -n "${SU_FEED_URL:-}" ]]; then
-    "$PLUTIL" -replace SUFeedURL -string "$SU_FEED_URL" "$APP_BUNDLE/Contents/Info.plist"
-else
-    "$PLUTIL" -remove SUFeedURL "$APP_BUNDLE/Contents/Info.plist" 2>/dev/null || true
-fi
+    if [[ -n "${SU_FEED_URL:-}" ]]; then
+        "$PLUTIL" -replace SUFeedURL -string "$SU_FEED_URL" "$APP_BUNDLE/Contents/Info.plist"
+    else
+        "$PLUTIL" -remove SUFeedURL "$APP_BUNDLE/Contents/Info.plist" 2>/dev/null || true
+    fi
 
-RESOURCE_BUNDLE="$BUILD_DIR/release/${APP_NAME}_${APP_NAME}.bundle"
-if [[ ! -d "$RESOURCE_BUNDLE" ]]; then
-    RESOURCE_BUNDLE="$(find "$BUILD_DIR" -path "*/release/${APP_NAME}_${APP_NAME}.bundle" -type d | head -n 1 || true)"
-fi
+    local resource_bundle="$BUILD_DIR/release/${APP_NAME}_${APP_NAME}.bundle"
+    if [[ ! -d "$resource_bundle" ]]; then
+        resource_bundle="$(find "$BUILD_DIR" -path "*/release/${APP_NAME}_${APP_NAME}.bundle" -type d | head -n 1 || true)"
+    fi
 
-if [[ -z "$RESOURCE_BUNDLE" || ! -d "$RESOURCE_BUNDLE" ]]; then
-    echo "Error: SwiftPM resource bundle not found for $APP_NAME"
-    exit 1
-fi
+    if [[ -z "$resource_bundle" || ! -d "$resource_bundle" ]]; then
+        echo "Error: SwiftPM resource bundle not found for $APP_NAME"
+        exit 1
+    fi
 
-echo "==> Bundling SwiftPM resources..."
-ditto "$RESOURCE_BUNDLE" "$APP_BUNDLE/Contents/Resources/$(basename "$RESOURCE_BUNDLE")"
+    echo "==> Bundling SwiftPM resources..."
+    ditto "$resource_bundle" "$APP_BUNDLE/Contents/Resources/$(basename "$resource_bundle")"
 
-# --- Compile Asset Catalog (generates Assets.car + AppIcon.icns) ---
-echo "==> Compiling Asset Catalog..."
-actool --compile "$APP_BUNDLE/Contents/Resources" \
-       --platform macosx \
-       --minimum-deployment-target 14.0 \
-       --app-icon AppIcon \
-       --output-partial-info-plist /dev/null \
-       "$PROJECT_DIR/Resources/Assets.xcassets" > /dev/null
+    echo "==> Compiling Asset Catalog..."
+    actool --compile "$APP_BUNDLE/Contents/Resources" \
+           --platform macosx \
+           --minimum-deployment-target 14.0 \
+           --app-icon AppIcon \
+           --output-partial-info-plist /dev/null \
+           "$PROJECT_DIR/Resources/Assets.xcassets" > /dev/null
 
-SPARKLE_FRAMEWORK="$(find "$BUILD_DIR" -path '*/Sparkle.framework' -type d | head -n 1 || true)"
-if [[ -n "$SPARKLE_FRAMEWORK" ]]; then
-    echo "==> Bundling Sparkle.framework..."
-    mkdir -p "$APP_BUNDLE/Contents/Frameworks"
-    ditto "$SPARKLE_FRAMEWORK" "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"
-fi
+    local sparkle_framework
+    sparkle_framework="$(find "$BUILD_DIR" -path '*/Sparkle.framework' -type d | head -n 1 || true)"
+    if [[ -n "$sparkle_framework" ]]; then
+        echo "==> Bundling Sparkle.framework..."
+        mkdir -p "$APP_BUNDLE/Contents/Frameworks"
+        ditto "$sparkle_framework" "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"
+    fi
 
-# --- Ad-hoc codesign ---
-echo "==> Codesigning (ad-hoc)..."
-if [[ -d "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework" ]]; then
-    while IFS= read -r nested_bundle; do
-        codesign --force --sign - "$nested_bundle"
-    done < <(find "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework" \
-        \( -name '*.app' -o -name '*.xpc' \) -type d | sort)
-    codesign --force --sign - "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"
-fi
-codesign --force --sign - "$APP_BUNDLE"
+    echo "==> Codesigning (ad-hoc)..."
+    if [[ -d "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework" ]]; then
+        while IFS= read -r nested_bundle; do
+            codesign --force --sign - "$nested_bundle"
+        done < <(find "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework" \
+            \( -name '*.app' -o -name '*.xpc' \) -type d | sort)
+        codesign --force --sign - "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"
+    fi
+    codesign --force --sign - "$APP_BUNDLE"
 
-echo "==> Built $APP_BUNDLE"
-codesign -v "$APP_BUNDLE"
-echo "==> Codesign verified OK"
+    echo "==> Built $APP_BUNDLE"
+    codesign -v "$APP_BUNDLE"
+    echo "==> Codesign verified OK"
+}
 
-# --- Zip if requested ---
-if [[ "${1:-}" == "--zip" ]]; then
-    ZIP_PATH="$PROJECT_DIR/$APP_NAME.zip"
+create_zip() {
     echo "==> Creating $ZIP_PATH..."
-    cd "$PROJECT_DIR"
-    rm -f "$APP_NAME.zip"
-    ditto -c -k --sequesterRsrc --keepParent "$APP_NAME.app" "$APP_NAME.zip"
+    rm -f "$ZIP_PATH"
+    ditto -c -k --sequesterRsrc --keepParent "$APP_BUNDLE" "$ZIP_PATH"
     echo "==> Done: $ZIP_PATH"
+}
+
+create_dmg() {
+    local staging_dir
+    staging_dir="$(mktemp -d "${TMPDIR:-/tmp}/claude-usage-bar-dmg.XXXXXX")"
+
+    echo "==> Creating $DMG_PATH..."
+    rm -f "$DMG_PATH"
+
+    ditto "$APP_BUNDLE" "$staging_dir/$APP_NAME.app"
+    ln -s /Applications "$staging_dir/Applications"
+    cat > "$staging_dir/Drag $APP_NAME to Applications.txt" <<EOF
+Drag $APP_NAME.app into the Applications folder alias to install.
+Launch the app from /Applications after copying it over.
+EOF
+
+    hdiutil create \
+        -volname "$APP_NAME" \
+        -srcfolder "$staging_dir" \
+        -format UDZO \
+        -ov \
+        "$DMG_PATH" > /dev/null
+
+    rm -rf "$staging_dir"
+    echo "==> Done: $DMG_PATH"
+}
+
+if [[ "$SKIP_BUILD" -eq 0 ]]; then
+    build_app_bundle
+elif [[ ! -d "$APP_BUNDLE" ]]; then
+    echo "Error: app bundle not found at $APP_BUNDLE"
+    exit 1
+fi
+
+if [[ "$CREATE_ZIP" -eq 1 ]]; then
+    create_zip
+fi
+
+if [[ "$CREATE_DMG" -eq 1 ]]; then
+    create_dmg
 fi

--- a/macos/scripts/verify-release.sh
+++ b/macos/scripts/verify-release.sh
@@ -4,48 +4,82 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 APP_NAME="ClaudeUsageBar"
-ZIP_PATH="${1:-$PROJECT_DIR/$APP_NAME.zip}"
+ARTIFACT_PATH="${1:-$PROJECT_DIR/$APP_NAME.zip}"
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/claude-usage-bar-release.XXXXXX")"
+MOUNT_DIR="$TMP_DIR/mount"
+DMG_ATTACHED=0
 
 cleanup() {
+    if [[ "$DMG_ATTACHED" -eq 1 ]]; then
+        hdiutil detach "$MOUNT_DIR" -quiet >/dev/null 2>&1 || true
+    fi
     rm -rf "$TMP_DIR"
 }
 trap cleanup EXIT
 
-if [[ ! -f "$ZIP_PATH" ]]; then
-    echo "Error: release archive not found at $ZIP_PATH"
+if [[ ! -f "$ARTIFACT_PATH" ]]; then
+    echo "Error: release archive not found at $ARTIFACT_PATH"
     exit 1
 fi
 
-APP_BUNDLE="$TMP_DIR/$APP_NAME.app"
-APP_PLIST="$APP_BUNDLE/Contents/Info.plist"
-RESOURCE_BUNDLE="$APP_BUNDLE/Contents/Resources/${APP_NAME}_${APP_NAME}.bundle"
-SPARKLE_FRAMEWORK="$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"
+verify_app_bundle() {
+    local app_bundle="$1"
+    local app_plist="$app_bundle/Contents/Info.plist"
+    local resource_bundle="$app_bundle/Contents/Resources/${APP_NAME}_${APP_NAME}.bundle"
+    local sparkle_framework="$app_bundle/Contents/Frameworks/Sparkle.framework"
 
-echo "==> Extracting $(basename "$ZIP_PATH")..."
-ditto -x -k "$ZIP_PATH" "$TMP_DIR"
+    echo "==> Verifying packaged resources..."
+    [[ -f "$app_plist" ]] || { echo "Error: missing Info.plist"; exit 1; }
+    [[ -d "$resource_bundle" ]] || { echo "Error: missing SwiftPM resource bundle"; exit 1; }
+    [[ -f "$resource_bundle/Info.plist" ]] || { echo "Error: missing resource bundle Info.plist"; exit 1; }
+    [[ -f "$resource_bundle/claude-logo.png" ]] || { echo "Error: missing packaged logo resource"; exit 1; }
+    [[ -f "$resource_bundle/en.lproj/Localizable.strings" ]] || { echo "Error: missing packaged localization resource"; exit 1; }
+    [[ -d "$sparkle_framework" ]] || { echo "Error: missing Sparkle.framework"; exit 1; }
 
-if [[ ! -d "$APP_BUNDLE" ]]; then
-    echo "Error: extracted archive did not contain $APP_NAME.app"
-    exit 1
-fi
+    echo "==> Verifying app signature..."
+    codesign -v "$app_bundle"
 
-echo "==> Verifying packaged resources..."
-[[ -f "$APP_PLIST" ]] || { echo "Error: missing Info.plist"; exit 1; }
-[[ -d "$RESOURCE_BUNDLE" ]] || { echo "Error: missing SwiftPM resource bundle"; exit 1; }
-[[ -f "$RESOURCE_BUNDLE/Info.plist" ]] || { echo "Error: missing resource bundle Info.plist"; exit 1; }
-[[ -f "$RESOURCE_BUNDLE/claude-logo.png" ]] || { echo "Error: missing packaged logo resource"; exit 1; }
-[[ -f "$RESOURCE_BUNDLE/en.lproj/Localizable.strings" ]] || { echo "Error: missing packaged localization resource"; exit 1; }
-[[ -d "$SPARKLE_FRAMEWORK" ]] || { echo "Error: missing Sparkle.framework"; exit 1; }
+    echo "==> Verifying updater metadata..."
+    plutil -extract SUPublicEDKey raw "$app_plist" >/dev/null
 
-echo "==> Verifying app signature..."
-codesign -v "$APP_BUNDLE"
+    if [[ "${EXPECT_FEED_URL:-0}" == "1" ]]; then
+        plutil -extract SUFeedURL raw "$app_plist" >/dev/null
+    fi
+}
 
-echo "==> Verifying updater metadata..."
-plutil -extract SUPublicEDKey raw "$APP_PLIST" >/dev/null
+case "$ARTIFACT_PATH" in
+    *.zip)
+        APP_BUNDLE="$TMP_DIR/$APP_NAME.app"
 
-if [[ "${EXPECT_FEED_URL:-0}" == "1" ]]; then
-    plutil -extract SUFeedURL raw "$APP_PLIST" >/dev/null
-fi
+        echo "==> Extracting $(basename "$ARTIFACT_PATH")..."
+        ditto -x -k "$ARTIFACT_PATH" "$TMP_DIR"
+
+        if [[ ! -d "$APP_BUNDLE" ]]; then
+            echo "Error: extracted archive did not contain $APP_NAME.app"
+            exit 1
+        fi
+
+        verify_app_bundle "$APP_BUNDLE"
+        ;;
+    *.dmg)
+        APP_BUNDLE="$MOUNT_DIR/$APP_NAME.app"
+        INSTRUCTIONS_FILE="$MOUNT_DIR/Drag $APP_NAME to Applications.txt"
+
+        echo "==> Mounting $(basename "$ARTIFACT_PATH")..."
+        mkdir -p "$MOUNT_DIR"
+        hdiutil attach "$ARTIFACT_PATH" -nobrowse -readonly -mountpoint "$MOUNT_DIR" > /dev/null
+        DMG_ATTACHED=1
+
+        [[ -d "$APP_BUNDLE" ]] || { echo "Error: mounted DMG did not contain $APP_NAME.app"; exit 1; }
+        [[ -L "$MOUNT_DIR/Applications" ]] || { echo "Error: mounted DMG is missing Applications symlink"; exit 1; }
+        [[ -f "$INSTRUCTIONS_FILE" ]] || { echo "Error: mounted DMG is missing drag-and-drop instructions"; exit 1; }
+
+        verify_app_bundle "$APP_BUNDLE"
+        ;;
+    *)
+        echo "Error: unsupported artifact type '$ARTIFACT_PATH'"
+        exit 1
+        ;;
+esac
 
 echo "==> Release archive looks good"


### PR DESCRIPTION
## Summary
- add DMG packaging for manual installs alongside the Sparkle ZIP
- verify packaged ZIP and DMG artifacts, including Gatekeeper checks for signed releases
- add optional notarization support for the app and DMG in the release workflow

## Testing
- swift test
- make release-artifacts