### PR TITLE
Fix negative usage chart hover values after reset

### DIFF
--- a/macos/Sources/ClaudeUsageBar/UsageChartView.swift
+++ b/macos/Sources/ClaudeUsageBar/UsageChartView.swift
@@ -31,7 +31,9 @@ struct UsageChartView: View {
 
     @ViewBuilder
     private func chartView(points: [UsageDataPoint]) -> some View {
-        let interpolated = hoverDate.flatMap { interpolateValues(at: $0, in: points) }
+        let interpolated = hoverDate.flatMap {
+            UsageChartInterpolation.interpolateValues(at: $0, in: points)
+        }
 
         Chart {
             ForEach(points) { point in
@@ -148,59 +150,6 @@ struct UsageChartView: View {
         .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 4))
     }
 
-    // MARK: - Interpolation
-
-    private struct InterpolatedValues {
-        let date: Date
-        let pct5h: Double
-        let pct7d: Double
-    }
-
-    private func catmullRom(_ p0: Double, _ p1: Double, _ p2: Double, _ p3: Double, t: Double) -> Double {
-        let t2 = t * t
-        let t3 = t2 * t
-        return 0.5 * (
-            (2 * p1) +
-            (-p0 + p2) * t +
-            (2 * p0 - 5 * p1 + 4 * p2 - p3) * t2 +
-            (-p0 + 3 * p1 - 3 * p2 + p3) * t3
-        )
-    }
-
-    private func interpolateValues(at date: Date, in points: [UsageDataPoint]) -> InterpolatedValues? {
-        guard points.count >= 2 else { return nil }
-
-        let sorted = points.sorted { $0.timestamp < $1.timestamp }
-
-        if date < sorted.first!.timestamp || date > sorted.last!.timestamp {
-            return InterpolatedValues(date: date, pct5h: 0, pct7d: 0)
-        }
-
-        for i in 0..<(sorted.count - 1) {
-            if date >= sorted[i].timestamp && date <= sorted[i + 1].timestamp {
-                let span = sorted[i + 1].timestamp.timeIntervalSince(sorted[i].timestamp)
-                let t = span > 0 ? date.timeIntervalSince(sorted[i].timestamp) / span : 0
-
-                // Four control points, clamping at boundaries
-                let i0 = max(0, i - 1)
-                let i3 = min(sorted.count - 1, i + 2)
-
-                let pct5h = catmullRom(
-                    sorted[i0].pct5h, sorted[i].pct5h,
-                    sorted[i + 1].pct5h, sorted[i3].pct5h, t: t
-                )
-                let pct7d = catmullRom(
-                    sorted[i0].pct7d, sorted[i].pct7d,
-                    sorted[i + 1].pct7d, sorted[i3].pct7d, t: t
-                )
-
-                return InterpolatedValues(date: date, pct5h: pct5h, pct7d: pct7d)
-            }
-        }
-
-        return nil
-    }
-
     // MARK: - Formatting
 
     private var xAxisFormat: Date.FormatStyle {
@@ -225,5 +174,65 @@ struct UsageChartView: View {
         case .day30:
             return .dateTime.month(.abbreviated).day().hour()
         }
+    }
+}
+
+struct UsageChartInterpolatedValues {
+    let date: Date
+    let pct5h: Double
+    let pct7d: Double
+}
+
+enum UsageChartInterpolation {
+    static func catmullRom(_ p0: Double, _ p1: Double, _ p2: Double, _ p3: Double, t: Double) -> Double {
+        let t2 = t * t
+        let t3 = t2 * t
+        return 0.5 * (
+            (2 * p1) +
+            (-p0 + p2) * t +
+            (2 * p0 - 5 * p1 + 4 * p2 - p3) * t2 +
+            (-p0 + 3 * p1 - 3 * p2 + p3) * t3
+        )
+    }
+
+    static func interpolateValues(at date: Date, in points: [UsageDataPoint]) -> UsageChartInterpolatedValues? {
+        guard points.count >= 2 else { return nil }
+
+        let sorted = points.sorted { $0.timestamp < $1.timestamp }
+
+        if date < sorted.first!.timestamp || date > sorted.last!.timestamp {
+            return UsageChartInterpolatedValues(date: date, pct5h: 0, pct7d: 0)
+        }
+
+        for i in 0..<(sorted.count - 1) {
+            if date >= sorted[i].timestamp && date <= sorted[i + 1].timestamp {
+                let span = sorted[i + 1].timestamp.timeIntervalSince(sorted[i].timestamp)
+                let t = span > 0 ? date.timeIntervalSince(sorted[i].timestamp) / span : 0
+
+                let i0 = max(0, i - 1)
+                let i3 = min(sorted.count - 1, i + 2)
+
+                let pct5h = catmullRom(
+                    sorted[i0].pct5h, sorted[i].pct5h,
+                    sorted[i + 1].pct5h, sorted[i3].pct5h, t: t
+                )
+                let pct7d = catmullRom(
+                    sorted[i0].pct7d, sorted[i].pct7d,
+                    sorted[i + 1].pct7d, sorted[i3].pct7d, t: t
+                )
+
+                return UsageChartInterpolatedValues(
+                    date: date,
+                    pct5h: clampToUnitInterval(pct5h),
+                    pct7d: clampToUnitInterval(pct7d)
+                )
+            }
+        }
+
+        return nil
+    }
+
+    private static func clampToUnitInterval(_ value: Double) -> Double {
+        min(max(value, 0), 1)
     }
 }

--- a/macos/Tests/ClaudeUsageBarTests/UsageChartInterpolationTests.swift
+++ b/macos/Tests/ClaudeUsageBarTests/UsageChartInterpolationTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import ClaudeUsageBar
+
+final class UsageChartInterpolationTests: XCTestCase {
+    func testInterpolateValuesClampsNegativeOvershootAfterReset() {
+        let base = Date(timeIntervalSince1970: 0)
+        let points = [
+            UsageDataPoint(timestamp: base, pct5h: 0.3, pct7d: 0.3),
+            UsageDataPoint(timestamp: base.addingTimeInterval(1), pct5h: 0.7, pct7d: 0.7),
+            UsageDataPoint(timestamp: base.addingTimeInterval(2), pct5h: 0.0, pct7d: 0.0),
+            UsageDataPoint(timestamp: base.addingTimeInterval(3), pct5h: 1.0, pct7d: 1.0),
+        ]
+
+        XCTAssertLessThan(
+            UsageChartInterpolation.catmullRom(0.3, 0.7, 0.0, 1.0, t: 0.966),
+            0
+        )
+
+        let interpolated = UsageChartInterpolation.interpolateValues(
+            at: base.addingTimeInterval(1.966),
+            in: points
+        )
+
+        XCTAssertEqual(interpolated?.pct5h, 0)
+        XCTAssertEqual(interpolated?.pct7d, 0)
+    }
+
+    func testInterpolateValuesClampsPositiveOvershootToHundredPercent() {
+        let base = Date(timeIntervalSince1970: 0)
+        let points = [
+            UsageDataPoint(timestamp: base, pct5h: 0.0, pct7d: 0.0),
+            UsageDataPoint(timestamp: base.addingTimeInterval(1), pct5h: 0.5, pct7d: 0.5),
+            UsageDataPoint(timestamp: base.addingTimeInterval(2), pct5h: 1.0, pct7d: 1.0),
+            UsageDataPoint(timestamp: base.addingTimeInterval(3), pct5h: 0.0, pct7d: 0.0),
+        ]
+
+        XCTAssertGreaterThan(
+            UsageChartInterpolation.catmullRom(0.0, 0.5, 1.0, 0.0, t: 0.911),
+            1
+        )
+
+        let interpolated = UsageChartInterpolation.interpolateValues(
+            at: base.addingTimeInterval(1.911),
+            in: points
+        )
+
+        XCTAssertEqual(interpolated?.pct5h, 1)
+        XCTAssertEqual(interpolated?.pct7d, 1)
+    }
+}


### PR DESCRIPTION
## Summary
- clamp interpolated hover values in the macOS usage chart to the valid 0...100% range
- extract the interpolation helper so the clamp behavior is directly testable
- add regression coverage for both below-zero and above-100 spline overshoot

## Root cause
The chart uses Catmull-Rom interpolation for hover values. Around reset boundaries, that spline can overshoot past the valid range even when the recorded samples are bounded, which is why the tooltip could briefly show negative percentages.

## Testing
- swift test

Closes #35