### PR TITLE
Harden credential storage, OAuth flow, and build pipeline

### DIFF
--- a/macos/Sources/ClaudeUsageBar/StoredCredentials.swift
+++ b/macos/Sources/ClaudeUsageBar/StoredCredentials.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Security
 
 struct StoredCredentials: Codable, Equatable {
     let accessToken: String
@@ -19,6 +20,9 @@ struct StoredCredentials: Codable, Equatable {
 
 struct StoredCredentialsStore {
     private let fileManager: FileManager
+    private let useKeychain: Bool
+    private let keychainService: String
+    private let keychainAccount: String
     let directoryURL: URL
     let credentialsFileURL: URL
     let legacyTokenFileURL: URL
@@ -26,28 +30,54 @@ struct StoredCredentialsStore {
     init(
         directoryURL: URL = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".config/claude-usage-bar", isDirectory: true),
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        useKeychain: Bool = true,
+        keychainService: String = "claude-usage-bar",
+        keychainAccount: String = "credentials"
     ) {
         self.fileManager = fileManager
+        self.useKeychain = useKeychain
+        self.keychainService = keychainService
+        self.keychainAccount = keychainAccount
         self.directoryURL = directoryURL
         self.credentialsFileURL = directoryURL.appendingPathComponent("credentials.json")
         self.legacyTokenFileURL = directoryURL.appendingPathComponent("token")
     }
 
     func save(_ credentials: StoredCredentials) throws {
-        try ensureDirectoryExists()
         let data = try Self.encoder.encode(credentials)
-        try data.write(to: credentialsFileURL, options: .atomic)
-        try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: credentialsFileURL.path)
+
+        if useKeychain {
+            try saveToKeychain(data)
+            // Remove file-based credentials after successful Keychain save
+            try? fileManager.removeItem(at: credentialsFileURL)
+        } else {
+            try ensureDirectoryExists()
+            try data.write(to: credentialsFileURL, options: .atomic)
+            try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: credentialsFileURL.path)
+        }
         try? fileManager.removeItem(at: legacyTokenFileURL)
     }
 
     func load(defaultScopes: [String]) -> StoredCredentials? {
-        if let data = try? Data(contentsOf: credentialsFileURL),
+        // 1. Try Keychain first
+        if useKeychain, let data = loadFromKeychain(),
            let credentials = try? Self.decoder.decode(StoredCredentials.self, from: data) {
             return credentials
         }
 
+        // 2. Try file-based credentials (migration path)
+        if let data = try? Data(contentsOf: credentialsFileURL),
+           let credentials = try? Self.decoder.decode(StoredCredentials.self, from: data) {
+            // Migrate to Keychain if available
+            if useKeychain {
+                try? saveToKeychain(data)
+                try? fileManager.removeItem(at: credentialsFileURL)
+            }
+            return credentials
+        }
+
+        // 3. Try legacy plaintext token file
         guard let data = try? Data(contentsOf: legacyTokenFileURL),
               let token = String(data: data, encoding: .utf8)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
@@ -64,9 +94,62 @@ struct StoredCredentialsStore {
     }
 
     func delete() {
+        if useKeychain {
+            deleteFromKeychain()
+        }
         try? fileManager.removeItem(at: credentialsFileURL)
         try? fileManager.removeItem(at: legacyTokenFileURL)
     }
+
+    // MARK: - Keychain Operations
+
+    private func keychainQuery() -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: keychainAccount,
+        ]
+    }
+
+    private func saveToKeychain(_ data: Data) throws {
+        let query = keychainQuery()
+
+        // Try update first, then add
+        let attributes: [String: Any] = [kSecValueData as String: data]
+        var status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+
+        if status == errSecItemNotFound {
+            var addQuery = query
+            addQuery[kSecValueData as String] = data
+            status = SecItemAdd(addQuery as CFDictionary, nil)
+        }
+
+        guard status == errSecSuccess else {
+            throw NSError(
+                domain: NSOSStatusErrorDomain,
+                code: Int(status),
+                userInfo: [NSLocalizedDescriptionKey: "Keychain save failed (OSStatus \(status))"]
+            )
+        }
+    }
+
+    private func loadFromKeychain() -> Data? {
+        var query = keychainQuery()
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess else { return nil }
+        return result as? Data
+    }
+
+    private func deleteFromKeychain() {
+        SecItemDelete(keychainQuery() as CFDictionary)
+    }
+
+    // MARK: - File Helpers
 
     private func ensureDirectoryExists() throws {
         try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)

--- a/macos/Sources/ClaudeUsageBar/StoredCredentials.swift
+++ b/macos/Sources/ClaudeUsageBar/StoredCredentials.swift
@@ -67,6 +67,8 @@ struct StoredCredentialsStore {
         }
 
         // 2. Try file-based credentials (migration path)
+        // Note: concurrent callers may both attempt migration; the second Keychain
+        // write is an idempotent update and the second file removal is a no-op.
         if let data = try? Data(contentsOf: credentialsFileURL),
            let credentials = try? Self.decoder.decode(StoredCredentials.self, from: data) {
             if useKeychain {
@@ -122,6 +124,8 @@ struct StoredCredentialsStore {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: keychainService,
             kSecAttrAccount as String: keychainAccount,
+            // App may launch before unlock as a login item (SMAppService)
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
         ]
     }
 
@@ -160,7 +164,10 @@ struct StoredCredentialsStore {
     }
 
     private func deleteFromKeychain() {
-        SecItemDelete(keychainQuery() as CFDictionary)
+        let status = SecItemDelete(keychainQuery() as CFDictionary)
+        if status != errSecSuccess && status != errSecItemNotFound {
+            NSLog("Keychain delete failed (OSStatus %d)", status)
+        }
     }
 
     // MARK: - File Helpers

--- a/macos/Sources/ClaudeUsageBar/StoredCredentials.swift
+++ b/macos/Sources/ClaudeUsageBar/StoredCredentials.swift
@@ -69,15 +69,18 @@ struct StoredCredentialsStore {
         // 2. Try file-based credentials (migration path)
         if let data = try? Data(contentsOf: credentialsFileURL),
            let credentials = try? Self.decoder.decode(StoredCredentials.self, from: data) {
-            // Migrate to Keychain if available
             if useKeychain {
-                try? saveToKeychain(data)
-                try? fileManager.removeItem(at: credentialsFileURL)
+                do {
+                    try saveToKeychain(data)
+                    try? fileManager.removeItem(at: credentialsFileURL)
+                } catch {
+                    // Keychain failed — keep the file as fallback
+                }
             }
             return credentials
         }
 
-        // 3. Try legacy plaintext token file
+        // 3. Try legacy plaintext token file — migrate to Keychain on success
         guard let data = try? Data(contentsOf: legacyTokenFileURL),
               let token = String(data: data, encoding: .utf8)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
@@ -85,12 +88,23 @@ struct StoredCredentialsStore {
             return nil
         }
 
-        return StoredCredentials(
+        let credentials = StoredCredentials(
             accessToken: token,
             refreshToken: nil,
             expiresAt: nil,
             scopes: defaultScopes
         )
+
+        if useKeychain, let encoded = try? Self.encoder.encode(credentials) {
+            do {
+                try saveToKeychain(encoded)
+                try? fileManager.removeItem(at: legacyTokenFileURL)
+            } catch {
+                // Keychain failed — keep the legacy file as fallback
+            }
+        }
+
+        return credentials
     }
 
     func delete() {

--- a/macos/Sources/ClaudeUsageBar/UsageHistoryService.swift
+++ b/macos/Sources/ClaudeUsageBar/UsageHistoryService.swift
@@ -74,7 +74,9 @@ class UsageHistoryService: ObservableObject {
         history.dataPoints = pruned(history.dataPoints)
 
         guard let data = try? JSONEncoder.historyEncoder.encode(history) else { return }
-        try? data.write(to: Self.historyFileURL, options: .atomic)
+        let url = Self.historyFileURL
+        try? data.write(to: url, options: .atomic)
+        try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
 
         isDirty = false
         flushTimer?.cancel()

--- a/macos/Sources/ClaudeUsageBar/UsageHistoryService.swift
+++ b/macos/Sources/ClaudeUsageBar/UsageHistoryService.swift
@@ -9,18 +9,20 @@ class UsageHistoryService: ObservableObject {
     private var flushTimer: AnyCancellable?
     private var isDirty = false
     private var terminationObserver: Any?
+    let historyFileURL: URL
 
     private static let retentionInterval: TimeInterval = 30 * 86400 // 30 days
     private static let flushInterval: TimeInterval = 300 // 5 minutes
 
-    private static var historyFileURL: URL {
+    private static var defaultHistoryFileURL: URL {
         let dir = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".config/claude-usage-bar", isDirectory: true)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         return dir.appendingPathComponent("history.json")
     }
 
-    init() {
+    init(historyFileURL: URL? = nil) {
+        self.historyFileURL = historyFileURL ?? Self.defaultHistoryFileURL
         terminationObserver = NotificationCenter.default.addObserver(
             forName: NSApplication.willTerminateNotification,
             object: nil, queue: .main
@@ -41,7 +43,7 @@ class UsageHistoryService: ObservableObject {
     // MARK: - Load
 
     func loadHistory() {
-        let url = Self.historyFileURL
+        let url = historyFileURL
         guard FileManager.default.fileExists(atPath: url.path) else { return }
 
         do {
@@ -74,9 +76,20 @@ class UsageHistoryService: ObservableObject {
         history.dataPoints = pruned(history.dataPoints)
 
         guard let data = try? JSONEncoder.historyEncoder.encode(history) else { return }
-        let url = Self.historyFileURL
-        try? data.write(to: url, options: .atomic)
-        try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+        let url = historyFileURL
+        let tempURL = url.appendingPathExtension("tmp")
+        try? FileManager.default.removeItem(at: tempURL)
+        guard FileManager.default.createFile(
+            atPath: tempURL.path,
+            contents: data,
+            attributes: [.posixPermissions: 0o600]
+        ) else { return }
+        do {
+            _ = try FileManager.default.replaceItemAt(url, withItemAt: tempURL)
+        } catch {
+            try? FileManager.default.removeItem(at: tempURL)
+            return
+        }
 
         isDirty = false
         flushTimer?.cancel()

--- a/macos/Sources/ClaudeUsageBar/UsageService.swift
+++ b/macos/Sources/ClaudeUsageBar/UsageService.swift
@@ -149,7 +149,15 @@ class UsageService: ObservableObject {
         let parts = rawCode.trimmingCharacters(in: .whitespacesAndNewlines).split(separator: "#", maxSplits: 1)
         let code = String(parts[0])
 
-        if parts.count > 1 {
+        // State validation is mandatory when an OAuth flow is pending
+        if oauthState != nil {
+            guard parts.count > 1 else {
+                lastError = "Missing OAuth state — expected code#state format"
+                isAwaitingCode = false
+                codeVerifier = nil
+                oauthState = nil
+                return
+            }
             let returnedState = String(parts[1])
             guard returnedState == oauthState else {
                 lastError = "OAuth state mismatch — try again"

--- a/macos/Sources/ClaudeUsageBar/UsageService.swift
+++ b/macos/Sources/ClaudeUsageBar/UsageService.swift
@@ -22,6 +22,7 @@ class UsageService: ObservableObject {
     private let tokenEndpoint: URL
     private let credentialsStore: StoredCredentialsStore
     private let localProfileLoader: @MainActor () -> String?
+    private let urlOpener: @MainActor (URL) -> Bool
     private var currentInterval: TimeInterval
     private var refreshTask: Task<Bool, Never>?
 
@@ -77,7 +78,8 @@ class UsageService: ObservableObject {
         tokenEndpoint: URL = UsageService.defaultTokenEndpoint,
         redirectUri: String = UsageService.defaultRedirectURI,
         credentialsStore: StoredCredentialsStore = StoredCredentialsStore(),
-        localProfileLoader: @MainActor @escaping () -> String? = UsageService.loadLocalProfile
+        localProfileLoader: @MainActor @escaping () -> String? = UsageService.loadLocalProfile,
+        urlOpener: @MainActor @escaping (URL) -> Bool = { NSWorkspace.shared.open($0) }
     ) {
         self.session = session
         self.usageEndpoint = usageEndpoint
@@ -86,6 +88,7 @@ class UsageService: ObservableObject {
         self.redirectUri = redirectUri
         self.credentialsStore = credentialsStore
         self.localProfileLoader = localProfileLoader
+        self.urlOpener = urlOpener
         let stored = UserDefaults.standard.integer(forKey: "pollingMinutes")
         let minutes = Self.pollingOptions.contains(stored) ? stored : Self.defaultPollingMinutes
         self.pollingMinutes = minutes
@@ -139,7 +142,13 @@ class UsageService: ObservableObject {
         ]
 
         if let url = components.url {
-            NSWorkspace.shared.open(url)
+            guard urlOpener(url) else {
+                codeVerifier = nil
+                oauthState = nil
+                isAwaitingCode = false
+                lastError = "Could not open Claude sign-in page"
+                return
+            }
             isAwaitingCode = true
         }
     }

--- a/macos/Tests/ClaudeUsageBarTests/StoredCredentialsTests.swift
+++ b/macos/Tests/ClaudeUsageBarTests/StoredCredentialsTests.swift
@@ -40,6 +40,79 @@ final class StoredCredentialsTests: XCTestCase {
         XCTAssertEqual(loaded.scopes, UsageService.defaultOAuthScopes)
     }
 
+    func testFileMigrationToKeychainRemovesFileOnSuccess() throws {
+        // Write credentials as file first (simulating pre-Keychain state)
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let fileStore = StoredCredentialsStore(directoryURL: directory, useKeychain: false)
+        let credentials = StoredCredentials(
+            accessToken: "migrate-me",
+            refreshToken: "refresh-migrate",
+            expiresAt: Date(timeIntervalSince1970: 1_741_194_400),
+            scopes: ["user:profile"]
+        )
+        try fileStore.save(credentials)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fileStore.credentialsFileURL.path))
+
+        // Now load with Keychain-enabled store — should migrate
+        let keychainService = "claude-usage-bar-test-\(UUID().uuidString)"
+        let keychainStore = StoredCredentialsStore(
+            directoryURL: directory,
+            useKeychain: true,
+            keychainService: keychainService
+        )
+
+        let loaded = try XCTUnwrap(keychainStore.load(defaultScopes: []))
+        XCTAssertEqual(loaded.accessToken, "migrate-me")
+        XCTAssertEqual(loaded.refreshToken, "refresh-migrate")
+
+        // File should be removed after successful Keychain migration
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fileStore.credentialsFileURL.path))
+
+        // Subsequent load should still work (from Keychain now)
+        let reloaded = try XCTUnwrap(keychainStore.load(defaultScopes: []))
+        XCTAssertEqual(reloaded.accessToken, "migrate-me")
+
+        // Cleanup Keychain
+        keychainStore.delete()
+    }
+
+    func testLegacyTokenMigrationToKeychainRemovesFile() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let keychainService = "claude-usage-bar-test-\(UUID().uuidString)"
+        let store = StoredCredentialsStore(
+            directoryURL: directory,
+            useKeychain: true,
+            keychainService: keychainService
+        )
+
+        // Write a legacy plaintext token file
+        try "legacy-token-to-migrate".write(
+            to: store.legacyTokenFileURL,
+            atomically: true,
+            encoding: .utf8
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: store.legacyTokenFileURL.path))
+
+        let loaded = try XCTUnwrap(store.load(defaultScopes: UsageService.defaultOAuthScopes))
+        XCTAssertEqual(loaded.accessToken, "legacy-token-to-migrate")
+
+        // Legacy file should be removed after Keychain migration
+        XCTAssertFalse(FileManager.default.fileExists(atPath: store.legacyTokenFileURL.path))
+
+        // Subsequent load from Keychain should work
+        let reloaded = try XCTUnwrap(store.load(defaultScopes: UsageService.defaultOAuthScopes))
+        XCTAssertEqual(reloaded.accessToken, "legacy-token-to-migrate")
+
+        // Cleanup Keychain
+        store.delete()
+    }
+
     private func makeStore() throws -> StoredCredentialsStore {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/macos/Tests/ClaudeUsageBarTests/StoredCredentialsTests.swift
+++ b/macos/Tests/ClaudeUsageBarTests/StoredCredentialsTests.swift
@@ -44,7 +44,7 @@ final class StoredCredentialsTests: XCTestCase {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        return StoredCredentialsStore(directoryURL: directory)
+        return StoredCredentialsStore(directoryURL: directory, useKeychain: false)
     }
 
     private func permissions(for url: URL) throws -> Int {

--- a/macos/Tests/ClaudeUsageBarTests/UsageHistoryServiceTests.swift
+++ b/macos/Tests/ClaudeUsageBarTests/UsageHistoryServiceTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import ClaudeUsageBar
+
+@MainActor
+final class UsageHistoryServiceTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    private func makeService() -> UsageHistoryService {
+        let url = tempDir.appendingPathComponent("history.json")
+        return UsageHistoryService(historyFileURL: url)
+    }
+
+    // MARK: - Flush persistence & permissions
+
+    func testFlushWritesFileWithCorrectPermissions() throws {
+        let service = makeService()
+        service.recordDataPoint(pct5h: 0.5, pct7d: 0.3)
+        service.flushToDisk()
+
+        let url = service.historyFileURL
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+
+        let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
+        let perms = attrs[.posixPermissions] as? Int
+        XCTAssertEqual(perms, 0o600, "History file should have 0600 permissions")
+    }
+
+    func testFlushDataRoundTrips() throws {
+        let service = makeService()
+        service.recordDataPoint(pct5h: 0.42, pct7d: 0.88)
+        service.flushToDisk()
+
+        let service2 = makeService()
+        service2.loadHistory()
+
+        XCTAssertEqual(service2.history.dataPoints.count, 1)
+        XCTAssertEqual(service2.history.dataPoints.first?.pct5h, 0.42, accuracy: 0.001)
+        XCTAssertEqual(service2.history.dataPoints.first?.pct7d, 0.88, accuracy: 0.001)
+    }
+
+    func testFlushPreservesExistingFileOnSecondWrite() throws {
+        let service = makeService()
+        service.recordDataPoint(pct5h: 0.1, pct7d: 0.2)
+        service.flushToDisk()
+
+        service.recordDataPoint(pct5h: 0.3, pct7d: 0.4)
+        service.flushToDisk()
+
+        let service2 = makeService()
+        service2.loadHistory()
+        XCTAssertEqual(service2.history.dataPoints.count, 2)
+    }
+
+    func testFlushIsNoOpWhenNotDirty() {
+        let service = makeService()
+
+        // Not dirty — flush should be a no-op
+        service.flushToDisk()
+
+        // File should not exist since there was nothing to write
+        XCTAssertFalse(FileManager.default.fileExists(atPath: service.historyFileURL.path))
+    }
+
+    func testPermissionsPreservedAfterMultipleFlushes() throws {
+        let service = makeService()
+        service.recordDataPoint(pct5h: 0.1, pct7d: 0.2)
+        service.flushToDisk()
+
+        service.recordDataPoint(pct5h: 0.3, pct7d: 0.4)
+        service.flushToDisk()
+
+        let attrs = try FileManager.default.attributesOfItem(atPath: service.historyFileURL.path)
+        let perms = attrs[.posixPermissions] as? Int
+        XCTAssertEqual(perms, 0o600, "Permissions should remain 0600 after multiple flushes")
+    }
+}

--- a/macos/Tests/ClaudeUsageBarTests/UsageServiceTests.swift
+++ b/macos/Tests/ClaudeUsageBarTests/UsageServiceTests.swift
@@ -272,6 +272,35 @@ final class UsageServiceTests: XCTestCase {
         XCTAssertEqual(saved.refreshToken, "refresh-new")
     }
 
+    func testSubmitOAuthCodeRejectsMissingState() async throws {
+        let store = try makeStore()
+        let tokenURL = URL(string: "https://example.com/v1/oauth/token")!
+
+        MockURLProtocol.handler = { request in
+            XCTFail("No network request should be made when state is missing")
+            return try Self.httpResponse(url: request.url!, statusCode: 500)
+        }
+
+        let service = UsageService(
+            session: makeSession(),
+            usageEndpoint: URL(string: "https://example.com/api/oauth/usage")!,
+            userinfoEndpoint: URL(string: "https://example.com/api/oauth/userinfo")!,
+            tokenEndpoint: tokenURL,
+            credentialsStore: store
+        )
+
+        // Start an OAuth flow so oauthState is set
+        service.startOAuthFlow()
+        XCTAssertTrue(service.isAwaitingCode)
+
+        // Submit code WITHOUT #state — should be rejected
+        await service.submitOAuthCode("some-auth-code")
+
+        XCTAssertFalse(service.isAwaitingCode)
+        XCTAssertFalse(service.isAuthenticated)
+        XCTAssertEqual(service.lastError, "Missing OAuth state — expected code#state format")
+    }
+
     private func makeStore() throws -> StoredCredentialsStore {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/macos/Tests/ClaudeUsageBarTests/UsageServiceTests.swift
+++ b/macos/Tests/ClaudeUsageBarTests/UsageServiceTests.swift
@@ -275,6 +275,7 @@ final class UsageServiceTests: XCTestCase {
     func testSubmitOAuthCodeRejectsMissingState() async throws {
         let store = try makeStore()
         let tokenURL = URL(string: "https://example.com/v1/oauth/token")!
+        var openedURL: URL?
 
         MockURLProtocol.handler = { request in
             XCTFail("No network request should be made when state is missing")
@@ -286,12 +287,17 @@ final class UsageServiceTests: XCTestCase {
             usageEndpoint: URL(string: "https://example.com/api/oauth/usage")!,
             userinfoEndpoint: URL(string: "https://example.com/api/oauth/userinfo")!,
             tokenEndpoint: tokenURL,
-            credentialsStore: store
+            credentialsStore: store,
+            urlOpener: { url in
+                openedURL = url
+                return true
+            }
         )
 
         // Start an OAuth flow so oauthState is set
         service.startOAuthFlow()
         XCTAssertTrue(service.isAwaitingCode)
+        XCTAssertTrue(openedURL?.absoluteString.hasPrefix("https://claude.ai/oauth/authorize") == true)
 
         // Submit code WITHOUT #state — should be rejected
         await service.submitOAuthCode("some-auth-code")
@@ -299,6 +305,30 @@ final class UsageServiceTests: XCTestCase {
         XCTAssertFalse(service.isAwaitingCode)
         XCTAssertFalse(service.isAuthenticated)
         XCTAssertEqual(service.lastError, "Missing OAuth state — expected code#state format")
+    }
+
+    func testStartOAuthFlowFailsCleanlyWhenBrowserCannotOpen() throws {
+        let store = try makeStore()
+        let tokenURL = URL(string: "https://example.com/v1/oauth/token")!
+        var openedURL: URL?
+
+        let service = UsageService(
+            session: makeSession(),
+            usageEndpoint: URL(string: "https://example.com/api/oauth/usage")!,
+            userinfoEndpoint: URL(string: "https://example.com/api/oauth/userinfo")!,
+            tokenEndpoint: tokenURL,
+            credentialsStore: store,
+            urlOpener: { url in
+                openedURL = url
+                return false
+            }
+        )
+
+        service.startOAuthFlow()
+
+        XCTAssertTrue(openedURL?.absoluteString.hasPrefix("https://claude.ai/oauth/authorize") == true)
+        XCTAssertFalse(service.isAwaitingCode)
+        XCTAssertEqual(service.lastError, "Could not open Claude sign-in page")
     }
 
     private func makeStore() throws -> StoredCredentialsStore {

--- a/macos/Tests/ClaudeUsageBarTests/UsageServiceTests.swift
+++ b/macos/Tests/ClaudeUsageBarTests/UsageServiceTests.swift
@@ -276,7 +276,7 @@ final class UsageServiceTests: XCTestCase {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        return StoredCredentialsStore(directoryURL: directory)
+        return StoredCredentialsStore(directoryURL: directory, useKeychain: false)
     }
 
     private func makeSession() -> URLSession {

--- a/macos/scripts/build.sh
+++ b/macos/scripts/build.sh
@@ -10,6 +10,7 @@ ZIP_PATH="$PROJECT_DIR/$APP_NAME.zip"
 DMG_PATH="$PROJECT_DIR/$APP_NAME.dmg"
 CREATE_DMG_VERSION="v1.2.3"
 CREATE_DMG_TARBALL_URL="https://github.com/create-dmg/create-dmg/archive/refs/tags/${CREATE_DMG_VERSION}.tar.gz"
+CREATE_DMG_SHA256="8cf7b4ae540801171f4f630f1f2956913aaa87483b7ac03458f52b6cd0c48953"
 DMG_RESOURCES_DIR="$PROJECT_DIR/Resources/dmg"
 DMG_BACKGROUND_SOURCE="$DMG_RESOURCES_DIR/background.png"
 APP_ICON_SOURCE="$PROJECT_DIR/Resources/AppIcon.icns"
@@ -187,7 +188,22 @@ create_dmg() {
 
     ditto "$APP_BUNDLE" "$staging_dir/$APP_NAME.app"
     create_applications_alias "$staging_dir"
-    curl -fsSL "$CREATE_DMG_TARBALL_URL" | tar -xzf - -C "$create_dmg_root" --strip-components=1
+    local tarball
+    tarball="$(mktemp "${TMPDIR:-/tmp}/create-dmg-tarball.XXXXXX.tar.gz")"
+    curl -fsSL "$CREATE_DMG_TARBALL_URL" -o "$tarball"
+
+    local actual_sha256
+    actual_sha256="$(shasum -a 256 "$tarball" | awk '{print $1}')"
+    if [[ "$actual_sha256" != "$CREATE_DMG_SHA256" ]]; then
+        echo "Error: create-dmg tarball SHA256 mismatch!"
+        echo "  expected: $CREATE_DMG_SHA256"
+        echo "  actual:   $actual_sha256"
+        rm -f "$tarball"
+        exit 1
+    fi
+
+    tar -xzf "$tarball" -C "$create_dmg_root" --strip-components=1
+    rm -f "$tarball"
     chmod +x "$create_dmg_tool"
 
     create_dmg_args=(

--- a/macos/scripts/build.sh
+++ b/macos/scripts/build.sh
@@ -10,6 +10,7 @@ ZIP_PATH="$PROJECT_DIR/$APP_NAME.zip"
 DMG_PATH="$PROJECT_DIR/$APP_NAME.dmg"
 CREATE_DMG_VERSION="v1.2.3"
 CREATE_DMG_TARBALL_URL="https://github.com/create-dmg/create-dmg/archive/refs/tags/${CREATE_DMG_VERSION}.tar.gz"
+# Update this hash whenever CREATE_DMG_VERSION is changed
 CREATE_DMG_SHA256="8cf7b4ae540801171f4f630f1f2956913aaa87483b7ac03458f52b6cd0c48953"
 DMG_RESOURCES_DIR="$PROJECT_DIR/Resources/dmg"
 DMG_BACKGROUND_SOURCE="$DMG_RESOURCES_DIR/background.png"
@@ -202,7 +203,11 @@ create_dmg() {
         exit 1
     fi
 
-    tar -xzf "$tarball" -C "$create_dmg_root" --strip-components=1
+    if ! tar -xzf "$tarball" -C "$create_dmg_root" --strip-components=1; then
+        echo "Error: failed to extract create-dmg tarball"
+        rm -f "$tarball"
+        exit 1
+    fi
     rm -f "$tarball"
     chmod +x "$create_dmg_tool"
 


### PR DESCRIPTION
## Summary

Harden credential storage, OAuth flow, and build pipeline integrity.

### Keychain credential storage
- Migrate credentials from file-based (`credentials.json`) to macOS Keychain
- Graceful fallback: if Keychain write fails, file-based storage is preserved
- Three-tier load order: Keychain → file (with auto-migration) → legacy plaintext token
- `deleteFromKeychain()` logs errors instead of silently discarding OSStatus
- File-based credentials and legacy token files are removed only after successful Keychain write
- Concurrent migration is safe — Keychain update is idempotent, second file removal is a no-op

### OAuth flow hardening
- State validation is now mandatory when an OAuth flow is pending (`oauthState != nil`)
  - Codes submitted without `#state` suffix are rejected with a clear error
  - This is a behavioral change: previously a code without state was accepted even mid-flow
- Browser open failure (`NSWorkspace.shared.open`) is handled — cleans up PKCE state and surfaces error
- `urlOpener` is injectable for testability without mocking `NSWorkspace`

### Build pipeline integrity
- `create-dmg` tarball is downloaded to a temp file and SHA256-verified before extraction
- Hash is pinned alongside the version constant with a reminder comment to update both together

### File permission hardening
- History file (`history.json`) is written atomically with `0o600` from creation via `FileManager.createFile(atPath:contents:attributes:)`
  - Previously had a brief window with default `0o644` permissions between write and chmod

### Tests
- `testFileMigrationToKeychainRemovesFileOnSuccess` — verifies file→Keychain migration removes the file
- `testLegacyTokenMigrationToKeychainRemovesFile` — verifies legacy token→Keychain migration
- `testSubmitOAuthCodeRejectsMissingState` — verifies code without state is rejected mid-flow
- `testStartOAuthFlowFailsCleanlyWhenBrowserCannotOpen` — verifies cleanup on browser failure
- Existing tests updated to pass `useKeychain: false` to remain unit-testable

## Test plan
- [ ] Verify fresh install stores credentials in Keychain (no `credentials.json` created)
- [ ] Verify existing `credentials.json` is migrated to Keychain on first load, file removed
- [ ] Verify existing legacy `token` file is migrated to Keychain on first load, file removed
- [ ] Verify sign-out deletes Keychain entry (check via Keychain Access.app)
- [ ] Verify OAuth flow rejects pasted code without `#state` suffix
- [ ] Verify OAuth flow shows error if browser fails to open
- [ ] Run `scripts/build.sh --dmg` and confirm SHA256 check passes
- [ ] Tamper with `CREATE_DMG_SHA256` and confirm build fails with mismatch error
- [ ] Verify `history.json` is created with `0o600` permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)