### PR TITLE
feat: display usage percentages on Dock tile icon

### DIFF
--- a/macos/Resources/Info.plist
+++ b/macos/Resources/Info.plist
@@ -21,7 +21,7 @@
     <key>CFBundleIconName</key>
     <string>AppIcon</string>
     <key>LSUIElement</key>
-    <true/>
+    <false/>
     <key>LSMinimumSystemVersion</key>
     <string>14.0</string>
     <key>SUEnableAutomaticChecks</key>

--- a/macos/Sources/ClaudeUsageBar/ClaudeUsageBarApp.swift
+++ b/macos/Sources/ClaudeUsageBar/ClaudeUsageBarApp.swift
@@ -1,4 +1,6 @@
 import SwiftUI
+import AppKit
+import Combine
 
 @main
 struct ClaudeUsageBarApp: App {
@@ -6,6 +8,7 @@ struct ClaudeUsageBarApp: App {
     @StateObject private var historyService = UsageHistoryService()
     @StateObject private var notificationService = NotificationService()
     @StateObject private var appUpdater = AppUpdater()
+    @StateObject private var dockTileUpdater = DockTileUpdater()
 
     var body: some Scene {
         MenuBarExtra {
@@ -29,6 +32,10 @@ struct ClaudeUsageBarApp: App {
                     service.historyService = historyService
                     service.notificationService = notificationService
                     service.startPolling()
+                    dockTileUpdater.bind(to: service)
+                }
+                .onReceive(service.objectWillChange) { _ in
+                    DispatchQueue.main.async { dockTileUpdater.update(service: service) }
                 }
         }
         .menuBarExtraStyle(.window)
@@ -41,5 +48,77 @@ struct ClaudeUsageBarApp: App {
         }
         .windowResizability(.contentSize)
         .windowStyle(.titleBar)
+    }
+}
+
+// MARK: - Dock Tile Updater
+
+@MainActor
+class DockTileUpdater: ObservableObject {
+    private var cancellables = Set<AnyCancellable>()
+
+    func bind(to service: UsageService) {
+        update(service: service)
+    }
+
+    func update(service: UsageService) {
+        let dockTile = NSApp.dockTile
+
+        if !service.isAuthenticated {
+            dockTile.badgeLabel = nil
+            dockTile.contentView = nil
+            dockTile.display()
+            return
+        }
+
+        let pct5h = Int(round(min(max(service.pct5h, 0), 1) * 100))
+        let pct7d = Int(round(min(max(service.pct7d, 0), 1) * 100))
+
+        let view = DockTileContentView(pct5h: pct5h, pct7d: pct7d)
+        let size = dockTile.size
+        let hostingView = NSHostingView(rootView: view)
+        hostingView.frame = NSRect(origin: .zero, size: size)
+
+        dockTile.contentView = hostingView
+        dockTile.display()
+    }
+}
+
+// MARK: - Dock Tile SwiftUI View
+
+struct DockTileContentView: View {
+    let pct5h: Int
+    let pct7d: Int
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack {
+                // Black background filling the entire icon
+                RoundedRectangle(cornerRadius: geo.size.width * 0.185)
+                    .fill(Color.black)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: geo.size.width * 0.185)
+                            .stroke(Color.white.opacity(0.3), lineWidth: 2)
+                    )
+
+                // Usage text centered
+                VStack(spacing: 6) {
+                    usageRow(label: "5h", pct: pct5h)
+                    usageRow(label: "7d", pct: pct7d)
+                }
+            }
+            .frame(width: geo.size.width, height: geo.size.height)
+        }
+    }
+
+    private func usageRow(label: String, pct: Int) -> some View {
+        HStack(spacing: 2) {
+            Text(label)
+                .font(.system(size: 24, weight: .medium, design: .monospaced))
+                .foregroundColor(Color.orange.opacity(0.6))
+            Text("\(pct)%")
+                .font(.system(size: 32, weight: .bold, design: .monospaced))
+                .foregroundColor(.orange)
+        }
     }
 }

--- a/macos/Sources/ClaudeUsageBar/MenuBarIconRenderer.swift
+++ b/macos/Sources/ClaudeUsageBar/MenuBarIconRenderer.swift
@@ -13,6 +13,12 @@ private let iconWidth: CGFloat = logoSize + logoGap + barsWidth
 private let iconHeight: CGFloat = 18
 private let fontSize: CGFloat = 8
 
+// Layout for percentage text mode
+private let pctFontSize: CGFloat = 9
+private let pctRowGap: CGFloat = 1
+private let pctLabelGap: CGFloat = 1
+private let pctIconLogoGap: CGFloat = 3
+
 private struct CachedLabel {
     let string: NSAttributedString
     let size: NSSize
@@ -38,20 +44,50 @@ private func drawRow(label: String, barX: CGFloat, barY: CGFloat, labelX: CGFloa
 }
 
 func renderIcon(pct5h: Double, pct7d: Double) -> NSImage {
-    let image = NSImage(size: NSSize(width: iconWidth, height: iconHeight), flipped: true) { _ in
-        let offset = logoSize + logoGap
-        let barX = offset + labelWidth + labelGap
-        let topY = (iconHeight - barHeight * 2 - rowGap) / 2
-        let bottomY = topY + barHeight + rowGap
+    // Render percentage text alongside the Claude logo
+    let font = NSFont.monospacedSystemFont(ofSize: pctFontSize, weight: .semibold)
+    let labelFont = NSFont.monospacedSystemFont(ofSize: 7, weight: .regular)
 
+    let pct5hInt = Int(round(min(max(pct5h, 0), 1) * 100))
+    let pct7dInt = Int(round(min(max(pct7d, 0), 1) * 100))
+
+    let attrs5h: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: NSColor.black]
+    let attrs7d: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: NSColor.black]
+    let labelAttrs: [NSAttributedString.Key: Any] = [.font: labelFont, .foregroundColor: NSColor.black.withAlphaComponent(0.6)]
+
+    let str5h = NSAttributedString(string: "\(pct5hInt)%", attributes: attrs5h)
+    let str7d = NSAttributedString(string: "\(pct7dInt)%", attributes: attrs7d)
+    let lbl5h = NSAttributedString(string: "5h", attributes: labelAttrs)
+    let lbl7d = NSAttributedString(string: "7d", attributes: labelAttrs)
+
+    let size5h = str5h.size()
+    let size7d = str7d.size()
+    let lblSize5h = lbl5h.size()
+    let lblSize7d = lbl7d.size()
+
+    // Each row: "5h " + "XX%"
+    let row1Width = lblSize5h.width + pctLabelGap + size5h.width
+    let row2Width = lblSize7d.width + pctLabelGap + size7d.width
+    let textWidth = max(row1Width, row2Width)
+    let totalWidth = logoSize + pctIconLogoGap + textWidth + 2
+
+    let image = NSImage(size: NSSize(width: totalWidth, height: iconHeight), flipped: true) { _ in
         drawClaudeLogo(x: 0, y: (iconHeight - logoSize) / 2, size: logoSize)
 
-        drawRow(label: "5h", barX: barX, barY: topY, labelX: offset) { x, y in
-            drawBar(x: x, y: y, width: barWidth, height: barHeight, cornerRadius: cornerRadius, pct: pct5h)
-        }
-        drawRow(label: "7d", barX: barX, barY: bottomY, labelX: offset) { x, y in
-            drawBar(x: x, y: y, width: barWidth, height: barHeight, cornerRadius: cornerRadius, pct: pct7d)
-        }
+        let textX = logoSize + pctIconLogoGap
+        let rowHeight = max(size5h.height, lblSize5h.height)
+        let totalTextHeight = rowHeight * 2 + pctRowGap
+        let topY = (iconHeight - totalTextHeight) / 2
+        let bottomY = topY + rowHeight + pctRowGap
+
+        // Row 1: "5h XX%"
+        lbl5h.draw(at: NSPoint(x: textX, y: topY + (rowHeight - lblSize5h.height) / 2))
+        str5h.draw(at: NSPoint(x: textX + lblSize5h.width + pctLabelGap, y: topY + (rowHeight - size5h.height) / 2))
+
+        // Row 2: "7d XX%"
+        lbl7d.draw(at: NSPoint(x: textX, y: bottomY + (rowHeight - lblSize7d.height) / 2))
+        str7d.draw(at: NSPoint(x: textX + lblSize7d.width + pctLabelGap, y: bottomY + (rowHeight - size7d.height) / 2))
+
         return true
     }
     image.isTemplate = true
@@ -59,20 +95,35 @@ func renderIcon(pct5h: Double, pct7d: Double) -> NSImage {
 }
 
 func renderUnauthenticatedIcon() -> NSImage {
-    let image = NSImage(size: NSSize(width: iconWidth, height: iconHeight), flipped: true) { _ in
-        let offset = logoSize + logoGap
-        let barX = offset + labelWidth + labelGap
-        let topY = (iconHeight - barHeight * 2 - rowGap) / 2
-        let bottomY = topY + barHeight + rowGap
+    let font = NSFont.monospacedSystemFont(ofSize: pctFontSize, weight: .semibold)
+    let labelFont = NSFont.monospacedSystemFont(ofSize: 7, weight: .regular)
+    let attrs: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: NSColor.black.withAlphaComponent(0.4)]
+    let labelAttrs: [NSAttributedString.Key: Any] = [.font: labelFont, .foregroundColor: NSColor.black.withAlphaComponent(0.3)]
 
+    let strDash = NSAttributedString(string: "--%", attributes: attrs)
+    let lbl5h = NSAttributedString(string: "5h", attributes: labelAttrs)
+    let lbl7d = NSAttributedString(string: "7d", attributes: labelAttrs)
+
+    let sizeDash = strDash.size()
+    let lblSize = lbl5h.size()
+    let textWidth = lblSize.width + pctLabelGap + sizeDash.width
+    let totalWidth = logoSize + pctIconLogoGap + textWidth + 2
+
+    let image = NSImage(size: NSSize(width: totalWidth, height: iconHeight), flipped: true) { _ in
         drawClaudeLogo(x: 0, y: (iconHeight - logoSize) / 2, size: logoSize)
 
-        drawRow(label: "5h", barX: barX, barY: topY, labelX: offset) { x, y in
-            drawDashedBar(x: x, y: y, width: barWidth, height: barHeight, cornerRadius: cornerRadius)
-        }
-        drawRow(label: "7d", barX: barX, barY: bottomY, labelX: offset) { x, y in
-            drawDashedBar(x: x, y: y, width: barWidth, height: barHeight, cornerRadius: cornerRadius)
-        }
+        let textX = logoSize + pctIconLogoGap
+        let rowHeight = max(sizeDash.height, lblSize.height)
+        let totalTextHeight = rowHeight * 2 + pctRowGap
+        let topY = (iconHeight - totalTextHeight) / 2
+        let bottomY = topY + rowHeight + pctRowGap
+
+        lbl5h.draw(at: NSPoint(x: textX, y: topY + (rowHeight - lblSize.height) / 2))
+        strDash.draw(at: NSPoint(x: textX + lblSize.width + pctLabelGap, y: topY + (rowHeight - sizeDash.height) / 2))
+
+        lbl7d.draw(at: NSPoint(x: textX, y: bottomY + (rowHeight - lblSize.height) / 2))
+        strDash.draw(at: NSPoint(x: textX + lblSize.width + pctLabelGap, y: bottomY + (rowHeight - sizeDash.height) / 2))
+
         return true
     }
     image.isTemplate = true


### PR DESCRIPTION
## Summary
- Show 5h and 7d usage percentages directly on the macOS Dock icon, making usage visible at a glance without needing to click the menu bar
- Dock tile renders as a black rounded rectangle with a subtle white stroke and orange percentage text
- Menu bar icon also updated to show percentage text instead of miniature progress bars

## Changes
- **Info.plist**: Set `LSUIElement` to `false` so the app appears in the Dock
- **ClaudeUsageBarApp.swift**: Added `DockTileUpdater` class that redraws the Dock icon via `NSDockTile` whenever usage data changes, and `DockTileContentView` SwiftUI view for the Dock tile rendering
- **MenuBarIconRenderer.swift**: Updated `renderIcon()` and `renderUnauthenticatedIcon()` to display percentage text (e.g. `5h 42%` / `7d 18%`) alongside the Claude logo instead of progress bars

## Test plan
- [ ] Launch the app and verify it appears in the Dock with usage percentages displayed
- [ ] Verify the menu bar icon shows percentage text
- [ ] Authenticate and confirm both Dock and menu bar update with real usage data
- [ ] Test light and dark mode appearance
- [ ] Right-click Dock icon > Options > Keep in Dock to verify pinning works

🤖 Generated with [Claude Code](https://claude.com/claude-code)