### PR TITLE
Fix crash on whitespace-only OAuth code submission

### DIFF
--- a/macos/Sources/ClaudeUsageBar/UsageService.swift
+++ b/macos/Sources/ClaudeUsageBar/UsageService.swift
@@ -152,7 +152,12 @@ class UsageService: ObservableObject {
     func submitOAuthCode(_ rawCode: String) async {
         // Response format: "code#state" — parse it
         let parts = rawCode.trimmingCharacters(in: .whitespacesAndNewlines).split(separator: "#", maxSplits: 1)
-        let code = String(parts[0])
+        // A whitespace-only paste trims to "" and yields no parts, so guard before
+        // indexing. Leave isAwaitingCode set so the user can retry without restarting.
+        guard let code = parts.first.map(String.init), !code.isEmpty else {
+            lastError = "No OAuth code entered"
+            return
+        }
 
         if parts.count > 1 {
             let returnedState = String(parts[1])

--- a/macos/Tests/ClaudeUsageBarTests/UsageServiceTests.swift
+++ b/macos/Tests/ClaudeUsageBarTests/UsageServiceTests.swift
@@ -646,6 +646,26 @@ final class UsageServiceTests: XCTestCase {
         XCTAssertEqual(saved.refreshToken, "refresh-2")
     }
 
+    // MARK: - OAuth code submission
+
+    /// A whitespace-only paste passes the `code.isEmpty` button guard (which checks
+    /// the raw, untrimmed field) but trims to "" inside `submitOAuthCode`, so `split`
+    /// returns no parts. Indexing `parts[0]` used to crash; it must now surface an error.
+    func testSubmitOAuthCodeWithWhitespaceOnlyInputShowsErrorWithoutCrashing() async throws {
+        let service = UsageService(
+            session: makeSession(),
+            usageEndpoint: URL(string: "https://example.com/api/oauth/usage")!,
+            userinfoEndpoint: URL(string: "https://example.com/api/oauth/userinfo")!,
+            tokenEndpoint: URL(string: "https://example.com/v1/oauth/token")!,
+            credentialsStore: try makeStore()
+        )
+
+        await service.submitOAuthCode("   ")
+
+        XCTAssertEqual(service.lastError, "No OAuth code entered")
+        XCTAssertFalse(service.isAuthenticated)
+    }
+
     private func makeStore() throws -> StoredCredentialsStore {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)


### PR DESCRIPTION
## Summary

Pasting or typing whitespace-only text into the manual OAuth code field hard-crashes the app with `Fatal error: Index out of range`.

The Submit button is `.disabled(code.isEmpty)` on the **raw, untrimmed** TextField value (`PopoverView.swift`), so a string of spaces/tabs/newlines is *not* empty and the button stays enabled. Inside `submitOAuthCode` the value is then trimmed:

```swift
let parts = rawCode.trimmingCharacters(in: .whitespacesAndNewlines).split(separator: "#", maxSplits: 1)
let code = String(parts[0])
```

`split` defaults to `omittingEmptySubsequences: true`, so a trimmed-to-`""` input returns an **empty** array and `parts[0]` traps. This is reachable from an ordinary copy-paste slip in the manual OAuth flow.

## Fix

Guard the parse and surface a clear error instead of indexing blindly:

```swift
guard let code = parts.first.map(String.init), !code.isEmpty else {
    lastError = "No OAuth code entered"
    return
}
```

`isAwaitingCode` is intentionally left set so the user can correct the input and retry without restarting the whole browser flow — unlike the state-mismatch / no-verifier guards, which abort because they are unrecoverable in place.

## Testing

- Reproduced the original crash standalone (`Fatal error: Index out of range`, exit 133) and confirmed the guarded logic returns the error path for `"   "`, `""`, `"\t\n"` while still parsing `code` and `code#state` correctly.
- Added `testSubmitOAuthCodeWithWhitespaceOnlyInputShowsErrorWithoutCrashing` to `UsageServiceTests`.
- Full suite passes locally on Xcode 26.5: **`swift test` → 45 tests, 0 failures** (44 existing + the new regression test). `swift build` is also green.

Single-purpose crash fix. Note this is independent of the OAuth hardening in #43, whose diff keeps the unguarded `String(parts[0])`, so the crash survives that PR.