### PR TITLE
Add Refresh icon + spinner and debounce to prevent self-rate-limiting

### DIFF
--- a/macos/Sources/ClaudeUsageBar/PopoverView.swift
+++ b/macos/Sources/ClaudeUsageBar/PopoverView.swift
@@ -6,6 +6,7 @@ struct PopoverView: View {
     @ObservedObject var notificationService: NotificationService
     @ObservedObject var appUpdater: AppUpdater
     @AppStorage("setupComplete") private var setupComplete = false
+    @State private var refreshCoolingDown = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -122,11 +123,25 @@ struct PopoverView: View {
         HStack(spacing: 12) {
             settingsButton
             Spacer()
-            Button("Refresh") {
-                Task { await service.fetchUsage() }
+            Button {
+                refresh()
+            } label: {
+                // ZStack keeps the label's footprint fixed (sized to the
+                // icon+text) so swapping in the spinner never shifts the
+                // surrounding layout. The circular-arrow icon makes the
+                // control read as a refresh action while staying flat and
+                // consistent with the other footer buttons.
+                ZStack {
+                    Label("Refresh", systemImage: "arrow.clockwise")
+                        .opacity(service.isFetching ? 0 : 1)
+                    ProgressView()
+                        .controlSize(.small)
+                        .opacity(service.isFetching ? 1 : 0)
+                }
             }
             .buttonStyle(.borderless)
             .font(.caption)
+            .disabled(service.isFetching || refreshCoolingDown)
             if appUpdater.isConfigured {
                 Button("Check for Updates…") {
                     appUpdater.checkForUpdates()
@@ -139,6 +154,19 @@ struct PopoverView: View {
                 .buttonStyle(.borderless)
                 .font(.caption)
                 .foregroundStyle(.secondary)
+        }
+    }
+
+    /// Manual refresh with a short cooldown so the button can't be hammered
+    /// into firing back-to-back requests and tripping rate limiting. The
+    /// in-flight request itself is also guarded inside `fetchUsage()`.
+    private func refresh() {
+        guard !service.isFetching && !refreshCoolingDown else { return }
+        refreshCoolingDown = true
+        Task { @MainActor in
+            await service.fetchUsage()
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            refreshCoolingDown = false
         }
     }
 

--- a/macos/Sources/ClaudeUsageBar/UsageService.swift
+++ b/macos/Sources/ClaudeUsageBar/UsageService.swift
@@ -9,6 +9,7 @@ class UsageService: ObservableObject {
     @Published var lastUpdated: Date?
     @Published var isAuthenticated = false
     @Published var isAwaitingCode = false
+    @Published private(set) var isFetching = false
     @Published private(set) var accountEmail: String?
 
     var historyService: UsageHistoryService?
@@ -262,6 +263,12 @@ class UsageService: ObservableObject {
             isAuthenticated = false
             return
         }
+
+        // Re-entrancy guard: ignore overlapping fetches so rapid manual
+        // refreshes can't fire concurrent requests and trip rate limiting.
+        guard !isFetching else { return }
+        isFetching = true
+        defer { isFetching = false }
 
         do {
             guard let result = try await sendAuthorizedRequest(to: usageEndpoint) else {


### PR DESCRIPTION
## Summary

**TL;DR:** stop people from hammering the Refresh button and rate-limiting themselves, and add a little spinner so you can see something's actually happening.

The Refresh button in the popover footer was plain text, so it didn't read as a control, and it could be clicked repeatedly — firing back-to-back usage requests that can trip the API rate limiter (HTTP 429). This PR:

- **Adds a refresh affordance** — the button gains a circular-arrow icon (`arrow.clockwise`) so it reads more like an actionable control than bare text. It stays flat (`.borderless`) and consistent with the neighbouring Settings…/Quit buttons. (A filled `.bordered` style was tried but looked too loud beside the other flat footer buttons.)
- **Adds in-flight feedback** — while a fetch runs, an in-place spinner replaces the icon. The label is a `ZStack` sized to the icon+text, so the spinner swaps in with no layout shift.
- **Debounces the button** — two layers: a re-entrancy guard in `UsageService.fetchUsage()` (`@Published isFetching`) so overlapping fetches (manual + timer poll, or two fast clicks) can't issue concurrent requests; and a 2-second cooldown on the button plus `.disabled` while fetching, so it can't be hammered.

`isFetching` is service-driven, so the spinner also reflects background poll activity — intentional, since it's accurate "the app is doing something" feedback.