### PR TITLE
Fix popover not resizing when content height changes

### DIFF
--- a/macos/Sources/ClaudeUsageBar/PopoverView.swift
+++ b/macos/Sources/ClaudeUsageBar/PopoverView.swift
@@ -6,6 +6,7 @@ struct PopoverView: View {
     @ObservedObject var notificationService: NotificationService
     @ObservedObject var appUpdater: AppUpdater
     @AppStorage("setupComplete") private var setupComplete = false
+    @State private var hostingWindow: NSWindow?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -27,6 +28,16 @@ struct PopoverView: View {
         }
         .padding()
         .frame(width: 340)
+        .background(GeometryReader { geo in
+            Color.clear.preference(key: PopoverContentSizeKey.self, value: geo.size)
+        })
+        .background(PopoverWindowLocator { w in
+            hostingWindow = w
+        })
+        .onPreferenceChange(PopoverContentSizeKey.self) { size in
+            guard size != .zero else { return }
+            hostingWindow?.setContentSize(size)
+        }
     }
 
     @ViewBuilder
@@ -370,5 +381,32 @@ private func colorForPct(_ pct: Double) -> Color {
     case ..<0.60: return .green
     case 0.60..<0.80: return .yellow
     default: return .red
+    }
+}
+
+// MARK: - Adaptive window sizing
+
+private struct PopoverContentSizeKey: PreferenceKey {
+    static var defaultValue: CGSize = .zero
+    static func reduce(value: inout CGSize, nextValue: () -> CGSize) { value = nextValue() }
+}
+
+private final class WindowObservingView: NSView {
+    var onWindow: ((NSWindow) -> Void)?
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if let w = window { onWindow?(w) }
+    }
+}
+
+private struct PopoverWindowLocator: NSViewRepresentable {
+    let onWindow: (NSWindow) -> Void
+    func makeNSView(context: Context) -> WindowObservingView {
+        let v = WindowObservingView()
+        v.onWindow = onWindow
+        return v
+    }
+    func updateNSView(_ v: WindowObservingView, context: Context) {
+        v.onWindow = onWindow
     }
 }


### PR DESCRIPTION
## Summary

- `MenuBarExtra(.window)` sets its panel size once on open and doesn't automatically resize when SwiftUI content reflows
- This left stale empty space at the bottom when content shrank (e.g. a "Resets in…" label dropping from two lines to one, or error labels appearing/disappearing)
- Fix tracks the rendered content size via a `PreferenceKey` + `GeometryReader`, captures the hosting `NSWindow` through `viewDidMoveToWindow()`, and calls `setContentSize(_:)` whenever the measured size changes

## How it works

Three small pieces added to `PopoverView.swift`:

1. **`PopoverContentSizeKey`** — preference key that propagates the measured content `CGSize` up the view tree
2. **`PopoverWindowLocator` + `WindowObservingView`** — `NSViewRepresentable` using `viewDidMoveToWindow()` to capture the `NSWindow` reference when the popover first appears
3. **Two `.background()` modifiers + `.onPreferenceChange`** on the root `VStack` — measures the actual rendered size and calls `window.setContentSize(size)` on every change; both backgrounds are inert to layout

## Test plan

- [ ] Open the popover — size looks correct on first open
- [ ] Wait for a "Resets in…" label to change line count — popover height adjusts with no leftover blank area
- [ ] Trigger an auth error and clear it — popover grows and shrinks correctly
- [ ] Toggle service status section on/off in Settings — popover resizes in both directions