### PR TITLE
Fix crash: guard against nil plotFrame in chart hover overlay

### DIFF
--- a/macos/Sources/ClaudeUsageBar/UsageChartView.swift
+++ b/macos/Sources/ClaudeUsageBar/UsageChartView.swift
@@ -110,7 +110,8 @@ struct UsageChartView: View {
                     .onContinuousHover { phase in
                         switch phase {
                         case .active(let location):
-                            let plotOrigin = geo[proxy.plotFrame!].origin
+                            guard let plotFrame = proxy.plotFrame else { return }
+                            let plotOrigin = geo[plotFrame].origin
                             let x = location.x - plotOrigin.x
                             if let date: Date = proxy.value(atX: x) {
                                 hoverDate = date


### PR DESCRIPTION
## Summary

`ChartProxy.plotFrame` is `Anchor<CGRect>?` and can be `nil` before the
chart completes its first layout pass. Force-unwrapping it with `!`
causes an `EXC_BAD_INSTRUCTION` crash when the cursor enters the chart
area shortly after the popover opens.

Replace the force-unwrap with `guard let` — if the frame isn't ready,
the hover event is silently ignored until layout is complete.

## Screenshots

N/A — crash fix with no visual change.

## Test plan

- [x] `make app` builds without errors
- [ ] Tested with mock server (if applicable)
- [x] Opened popover and immediately hovered over chart — no crash