### PR TITLE
Fix history loss on reboot: flush to disk on every data point

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,23 +12,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build release binary
-        run: cd macos && swift build -c release
+      - name: Log Xcode version
+        run: xcodebuild -version
+
+      - name: Cache SPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            macos/.build/checkouts
+            macos/.build/artifacts
+          key: spm-${{ runner.os }}-${{ hashFiles('macos/Package.resolved') }}
+          restore-keys: |
+            spm-${{ runner.os }}-
 
       - name: Run tests
         run: cd macos && swift test
 
-      - name: Build app archives
-        run: make release-artifacts
-
-      - name: Upload ZIP artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ClaudeUsageBar.zip
-          path: macos/ClaudeUsageBar.zip
-
-      - name: Upload DMG artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ClaudeUsageBar.dmg
-          path: macos/ClaudeUsageBar.dmg
+      - name: Build app bundle
+        run: make app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,19 @@ jobs:
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5
 
+      - name: Cache SPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            macos/.build/checkouts
+            macos/.build/artifacts
+          key: spm-${{ runner.os }}-${{ hashFiles('macos/Package.resolved') }}
+          restore-keys: |
+            spm-${{ runner.os }}-
+
+      - name: Run tests
+        run: cd macos && swift test
+
       - name: Build release app bundle
         run: |
           version="${GITHUB_REF_NAME#v}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,14 @@ jobs:
       contents: write
     env:
       REPOSITORY_NAME: ${{ github.event.repository.name }}
+    outputs:
+      appcast_generated: ${{ steps.appcast.outputs.generated }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5
+        continue-on-error: true
 
       - name: Cache SPM dependencies
         uses: actions/cache@v4
@@ -35,17 +38,22 @@ jobs:
         run: cd macos && swift test
 
       - name: Build release app bundle
+        env:
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
         run: |
           version="${GITHUB_REF_NAME#v}"
           owner="$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')"
           export APP_VERSION="$version"
-          export SU_FEED_URL="https://${owner}.github.io/${REPOSITORY_NAME}/appcast.xml"
+          if [[ -n "${SPARKLE_PRIVATE_KEY:-}" ]]; then
+            export SU_FEED_URL="https://${owner}.github.io/${REPOSITORY_NAME}/appcast.xml"
+          fi
           bash macos/scripts/build.sh
 
       - name: Package and verify release artifacts
         env:
-          EXPECT_FEED_URL: '1'
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
         run: |
+          [[ -n "${SPARKLE_PRIVATE_KEY:-}" ]] && export EXPECT_FEED_URL=1
           bash macos/scripts/build.sh --skip-build --zip --dmg
           make verify-release
 
@@ -99,12 +107,14 @@ jobs:
           body_path: dist/release-notes.md
 
       - name: Generate Sparkle appcast
+        id: appcast
         env:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
         run: |
           if [[ -z "${SPARKLE_PRIVATE_KEY:-}" ]]; then
-            echo "::error::Missing SPARKLE_PRIVATE_KEY repository secret."
-            exit 1
+            echo "::warning::SPARKLE_PRIVATE_KEY not set — skipping appcast. Sparkle auto-updates will not work for this release."
+            echo "generated=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           cp macos/ClaudeUsageBar.zip dist/archives/ClaudeUsageBar.zip
@@ -117,13 +127,17 @@ jobs:
               --maximum-deltas 0 \
               -o dist/site/appcast.xml
 
+          echo "generated=true" >> "$GITHUB_OUTPUT"
+
       - name: Upload appcast for GitHub Pages
+        if: steps.appcast.outputs.generated == 'true'
         uses: actions/upload-pages-artifact@v4
         with:
           path: dist/site
 
   deploy_appcast:
     needs: release
+    if: needs.release.outputs.appcast_generated == 'true'
     runs-on: ubuntu-latest
     permissions:
       pages: write

--- a/macos/Sources/ClaudeUsageBar/PopoverView.swift
+++ b/macos/Sources/ClaudeUsageBar/PopoverView.swift
@@ -16,8 +16,13 @@ struct PopoverView: View {
                     onComplete: { setupComplete = true }
                 )
             } else {
-                Text("Claude Usage")
-                    .font(.headline)
+                HStack(spacing: 8) {
+                    Image(systemName: "chart.bar.fill")
+                        .foregroundStyle(.tint)
+                    Text("Claude Usage")
+                        .font(.title3)
+                        .fontWeight(.semibold)
+                }
                 if !service.isAuthenticated {
                     signInView
                 } else {
@@ -78,70 +83,72 @@ struct PopoverView: View {
 
         if let opus = service.usage?.sevenDayOpus,
            opus.utilization != nil {
-            Divider()
-            Text("Per-Model (7 day)")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-            UsageBucketRow(label: "Opus", bucket: opus)
-            if let sonnet = service.usage?.sevenDaySonnet {
-                UsageBucketRow(label: "Sonnet", bucket: sonnet)
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Per-Model (7 day)")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 2)
+                UsageBucketRow(label: "Opus", bucket: opus)
+                if let sonnet = service.usage?.sevenDaySonnet {
+                    UsageBucketRow(label: "Sonnet", bucket: sonnet)
+                }
             }
         }
 
         if let extra = service.usage?.extraUsage, extra.isEnabled {
-            Divider()
             ExtraUsageRow(extra: extra)
         }
 
-        Divider()
         UsageChartView(historyService: historyService)
 
         if let error = service.lastError {
-            Divider()
             Label(error, systemImage: "exclamationmark.triangle")
                 .foregroundStyle(.red)
                 .font(.caption)
         }
 
         if let updaterError = appUpdater.lastError {
-            Divider()
             Label(updaterError, systemImage: "arrow.triangle.2.circlepath.circle")
                 .foregroundStyle(.red)
                 .font(.caption)
         }
 
-        Divider()
+        footerView
+    }
 
-        HStack(spacing: 12) {
+    private var footerView: some View {
+        VStack(alignment: .leading, spacing: 4) {
             if let updated = service.lastUpdated {
                 Text("Updated \(updated, style: .relative) ago")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
             }
-            Spacer()
-        }
-
-        HStack(spacing: 12) {
-            settingsButton
-            Spacer()
-            Button("Refresh") {
-                Task { await service.fetchUsage() }
-            }
-            .buttonStyle(.borderless)
-            .font(.caption)
-            if appUpdater.isConfigured {
-                Button("Check for Updates…") {
-                    appUpdater.checkForUpdates()
+            HStack(spacing: 10) {
+                settingsButton
+                Spacer()
+                Button("Refresh") {
+                    Task { await service.fetchUsage() }
                 }
                 .buttonStyle(.borderless)
                 .font(.caption)
-                .disabled(!appUpdater.canCheckForUpdates)
+                if appUpdater.isConfigured {
+                    Button("Check for Updates…") {
+                        appUpdater.checkForUpdates()
+                    }
+                    .buttonStyle(.borderless)
+                    .font(.caption)
+                    .disabled(!appUpdater.canCheckForUpdates)
+                }
+                Button("Quit") { NSApplication.shared.terminate(nil) }
+                    .buttonStyle(.borderless)
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
             }
-            Button("Quit") { NSApplication.shared.terminate(nil) }
-                .buttonStyle(.borderless)
-                .font(.caption)
-                .foregroundStyle(.secondary)
         }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
     }
 
     private var settingsButton: some View {
@@ -286,17 +293,19 @@ private struct CodeEntryView: View {
 private struct UsageBucketRow: View {
     let label: String
     let bucket: UsageBucket?
-    var forecastPct: Double? = nil  // projected utilization, 0…1
+    var forecastPct: Double? = nil
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: 6) {
             HStack {
                 Text(label)
                     .font(.subheadline)
+                    .fontWeight(.medium)
                 Spacer()
                 Text(percentageText)
                     .font(.subheadline)
                     .monospacedDigit()
+                    .fontWeight(.semibold)
             }
             UsageProgressBar(
                 value: (bucket?.utilization ?? 0) / 100.0,
@@ -305,9 +314,11 @@ private struct UsageBucketRow: View {
             if let resetDate = bucket?.resetsAtDate {
                 Text("Resets \(resetDate, style: .relative)")
                     .font(.caption2)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(.tertiary)
             }
         }
+        .padding(10)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
     }
 
     private var percentageText: String {
@@ -317,31 +328,31 @@ private struct UsageBucketRow: View {
 }
 
 private struct UsageProgressBar: View {
-    let value: Double       // current utilization, 0…1
-    var forecast: Double? = nil  // projected utilization, 0…1; nil hides the marker
+    let value: Double
+    var forecast: Double? = nil
 
-    private let barHeight: CGFloat = 4
-    private let markerHeight: CGFloat = 8
+    private let barHeight: CGFloat = 6
+    private let markerHeight: CGFloat = 10
 
     var body: some View {
         GeometryReader { geo in
             let clamped = min(max(value, 0), 1)
+            let fillColor = colorForPct(clamped)
             ZStack(alignment: .leading) {
-                // Track
                 Capsule()
-                    .fill(Color.secondary.opacity(0.2))
+                    .fill(Color.primary.opacity(0.08))
                     .frame(width: geo.size.width, height: barHeight)
 
-                // Current-utilization fill
                 if clamped > 0 {
                     Capsule()
-                        .fill(colorForPct(clamped))
+                        .fill(LinearGradient(
+                            colors: [fillColor.opacity(0.75), fillColor],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        ))
                         .frame(width: geo.size.width * clamped, height: barHeight)
                 }
 
-                // Forecast marker — thin vertical line centered at the projected position.
-                // Uses primary label colour (black/white per appearance) so it contrasts
-                // with both the light gray track and the coloured fill in light and dark mode.
                 if let f = forecast {
                     let fx = min(max(f, 0), 1)
                     RoundedRectangle(cornerRadius: 1)
@@ -359,9 +370,10 @@ private struct ExtraUsageRow: View {
     let extra: ExtraUsage
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: 6) {
             Text("Extra Usage")
                 .font(.subheadline)
+                .fontWeight(.medium)
             if let used = extra.usedCreditsAmount, let limit = extra.monthlyLimitAmount {
                 HStack {
                     Text("\(ExtraUsage.formatUSD(used)) / \(ExtraUsage.formatUSD(limit))")
@@ -372,12 +384,14 @@ private struct ExtraUsageRow: View {
                         Text("\(Int(round(pct)))%")
                             .font(.caption)
                             .monospacedDigit()
+                            .fontWeight(.semibold)
                     }
                 }
-                ProgressView(value: (extra.utilization ?? 0) / 100.0, total: 1.0)
-                    .tint(.blue)
+                UsageProgressBar(value: (extra.utilization ?? 0) / 100.0)
             }
         }
+        .padding(10)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
     }
 }
 
@@ -411,8 +425,9 @@ private struct SetupThresholdSlider: View {
 
 private func colorForPct(_ pct: Double) -> Color {
     switch pct {
-    case ..<0.60: return .green
+    case ..<0.60: return .mint
     case 0.60..<0.80: return .yellow
+    case 0.80..<0.90: return .orange
     default: return .red
     }
 }

--- a/macos/Sources/ClaudeUsageBar/PopoverView.swift
+++ b/macos/Sources/ClaudeUsageBar/PopoverView.swift
@@ -66,12 +66,14 @@ struct PopoverView: View {
     private var usageView: some View {
         UsageBucketRow(
             label: "5-Hour Window",
-            bucket: service.usage?.fiveHour
+            bucket: service.usage?.fiveHour,
+            forecastPct: service.forecast.map { $0.projected5h / 100.0 }
         )
 
         UsageBucketRow(
             label: "7-Day Window",
-            bucket: service.usage?.sevenDay
+            bucket: service.usage?.sevenDay,
+            forecastPct: service.forecast.map { $0.projected7d / 100.0 }
         )
 
         if let opus = service.usage?.sevenDayOpus,
@@ -284,6 +286,7 @@ private struct CodeEntryView: View {
 private struct UsageBucketRow: View {
     let label: String
     let bucket: UsageBucket?
+    var forecastPct: Double? = nil  // projected utilization, 0…1
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -295,8 +298,10 @@ private struct UsageBucketRow: View {
                     .font(.subheadline)
                     .monospacedDigit()
             }
-            ProgressView(value: (bucket?.utilization ?? 0) / 100.0, total: 1.0)
-                .tint(colorForPct((bucket?.utilization ?? 0) / 100.0))
+            UsageProgressBar(
+                value: (bucket?.utilization ?? 0) / 100.0,
+                forecast: forecastPct
+            )
             if let resetDate = bucket?.resetsAtDate {
                 Text("Resets \(resetDate, style: .relative)")
                     .font(.caption2)
@@ -308,6 +313,45 @@ private struct UsageBucketRow: View {
     private var percentageText: String {
         guard let pct = bucket?.utilization else { return "—" }
         return "\(Int(round(pct)))%"
+    }
+}
+
+private struct UsageProgressBar: View {
+    let value: Double       // current utilization, 0…1
+    var forecast: Double? = nil  // projected utilization, 0…1; nil hides the marker
+
+    private let barHeight: CGFloat = 4
+    private let markerHeight: CGFloat = 8
+
+    var body: some View {
+        GeometryReader { geo in
+            let clamped = min(max(value, 0), 1)
+            ZStack(alignment: .leading) {
+                // Track
+                Capsule()
+                    .fill(Color.secondary.opacity(0.2))
+                    .frame(width: geo.size.width, height: barHeight)
+
+                // Current-utilization fill
+                if clamped > 0 {
+                    Capsule()
+                        .fill(colorForPct(clamped))
+                        .frame(width: geo.size.width * clamped, height: barHeight)
+                }
+
+                // Forecast marker — thin vertical line centered at the projected position.
+                // White fill with a soft shadow keeps it legible over any fill colour.
+                if let f = forecast {
+                    let fx = min(max(f, 0), 1)
+                    RoundedRectangle(cornerRadius: 1)
+                        .fill(Color.white)
+                        .frame(width: 2, height: markerHeight)
+                        .shadow(color: .black.opacity(0.3), radius: 1, x: 0, y: 0)
+                        .offset(x: geo.size.width * fx - 1)
+                }
+            }
+        }
+        .frame(height: markerHeight)
     }
 }
 

--- a/macos/Sources/ClaudeUsageBar/PopoverView.swift
+++ b/macos/Sources/ClaudeUsageBar/PopoverView.swift
@@ -340,13 +340,13 @@ private struct UsageProgressBar: View {
                 }
 
                 // Forecast marker — thin vertical line centered at the projected position.
-                // White fill with a soft shadow keeps it legible over any fill colour.
+                // Uses primary label colour (black/white per appearance) so it contrasts
+                // with both the light gray track and the coloured fill in light and dark mode.
                 if let f = forecast {
                     let fx = min(max(f, 0), 1)
                     RoundedRectangle(cornerRadius: 1)
-                        .fill(Color.white)
+                        .fill(Color.primary.opacity(0.7))
                         .frame(width: 2, height: markerHeight)
-                        .shadow(color: .black.opacity(0.3), radius: 1, x: 0, y: 0)
                         .offset(x: geo.size.width * fx - 1)
                 }
             }

--- a/macos/Sources/ClaudeUsageBar/PopoverView.swift
+++ b/macos/Sources/ClaudeUsageBar/PopoverView.swift
@@ -6,6 +6,7 @@ struct PopoverView: View {
     @ObservedObject var notificationService: NotificationService
     @ObservedObject var appUpdater: AppUpdater
     @AppStorage("setupComplete") private var setupComplete = false
+    @State private var hostingWindow: NSWindow?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -32,6 +33,16 @@ struct PopoverView: View {
         }
         .padding()
         .frame(width: 340)
+        .background(GeometryReader { geo in
+            Color.clear.preference(key: PopoverContentSizeKey.self, value: geo.size)
+        })
+        .background(PopoverWindowLocator { w in
+            hostingWindow = w
+        })
+        .onPreferenceChange(PopoverContentSizeKey.self) { size in
+            guard size != .zero else { return }
+            hostingWindow?.setContentSize(size)
+        }
     }
 
     @ViewBuilder
@@ -429,5 +440,32 @@ private func colorForPct(_ pct: Double) -> Color {
     case 0.60..<0.80: return .yellow
     case 0.80..<0.90: return .orange
     default: return .red
+    }
+}
+
+// MARK: - Adaptive window sizing
+
+private struct PopoverContentSizeKey: PreferenceKey {
+    static var defaultValue: CGSize = .zero
+    static func reduce(value: inout CGSize, nextValue: () -> CGSize) { value = nextValue() }
+}
+
+private final class WindowObservingView: NSView {
+    var onWindow: ((NSWindow) -> Void)?
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if let w = window { onWindow?(w) }
+    }
+}
+
+private struct PopoverWindowLocator: NSViewRepresentable {
+    let onWindow: (NSWindow) -> Void
+    func makeNSView(context: Context) -> WindowObservingView {
+        let v = WindowObservingView()
+        v.onWindow = onWindow
+        return v
+    }
+    func updateNSView(_ v: WindowObservingView, context: Context) {
+        v.onWindow = onWindow
     }
 }

--- a/macos/Sources/ClaudeUsageBar/UsageChartView.swift
+++ b/macos/Sources/ClaudeUsageBar/UsageChartView.swift
@@ -42,7 +42,7 @@ struct UsageChartView: View {
                     y: .value("Usage", point.pct5h * 100)
                 )
                 .foregroundStyle(by: .value("Window", "5h"))
-                .interpolationMethod(.catmullRom)
+                .interpolationMethod(.monotone)
             }
 
             ForEach(points) { point in
@@ -51,7 +51,7 @@ struct UsageChartView: View {
                     y: .value("Usage", point.pct7d * 100)
                 )
                 .foregroundStyle(by: .value("Window", "7d"))
-                .interpolationMethod(.catmullRom)
+                .interpolationMethod(.monotone)
             }
 
             if let iv = interpolated {

--- a/macos/Sources/ClaudeUsageBar/UsageChartView.swift
+++ b/macos/Sources/ClaudeUsageBar/UsageChartView.swift
@@ -37,12 +37,39 @@ struct UsageChartView: View {
 
         Chart {
             ForEach(points) { point in
+                AreaMark(
+                    x: .value("Time", point.timestamp),
+                    y: .value("Usage", point.pct5h * 100)
+                )
+                .interpolationMethod(.monotone)
+                .foregroundStyle(LinearGradient(
+                    colors: [Color.blue.opacity(0.18), Color.blue.opacity(0)],
+                    startPoint: .top,
+                    endPoint: .bottom
+                ))
+            }
+
+            ForEach(points) { point in
+                AreaMark(
+                    x: .value("Time", point.timestamp),
+                    y: .value("Usage", point.pct7d * 100)
+                )
+                .interpolationMethod(.monotone)
+                .foregroundStyle(LinearGradient(
+                    colors: [Color.orange.opacity(0.18), Color.orange.opacity(0)],
+                    startPoint: .top,
+                    endPoint: .bottom
+                ))
+            }
+
+            ForEach(points) { point in
                 LineMark(
                     x: .value("Time", point.timestamp),
                     y: .value("Usage", point.pct5h * 100)
                 )
                 .foregroundStyle(by: .value("Window", "5h"))
                 .interpolationMethod(.monotone)
+                .lineStyle(StrokeStyle(lineWidth: 2))
             }
 
             ForEach(points) { point in
@@ -52,6 +79,7 @@ struct UsageChartView: View {
                 )
                 .foregroundStyle(by: .value("Window", "7d"))
                 .interpolationMethod(.monotone)
+                .lineStyle(StrokeStyle(lineWidth: 2))
             }
 
             if let iv = interpolated {
@@ -147,7 +175,7 @@ struct UsageChartView: View {
         }
         .padding(.horizontal, 6)
         .padding(.vertical, 3)
-        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 4))
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8))
     }
 
     // MARK: - Formatting

--- a/macos/Sources/ClaudeUsageBar/UsageForecastService.swift
+++ b/macos/Sources/ClaudeUsageBar/UsageForecastService.swift
@@ -1,0 +1,735 @@
+import Foundation
+
+// MARK: - Output
+
+/// Forecast of near-future utilization for both Claude rolling-window metrics.
+///
+/// All utilization projections (`projected*`, `*Bound*`) are percentages in 0…100,
+/// matching the `UsageBucket.utilization` scale returned by the API.
+/// Velocity is in %/hour; acceleration is in %/hour².
+struct UsageForecast {
+    /// Smoothed and extrapolated 5-hour utilization at the forecast horizon.
+    let projected5h: Double
+    /// Smoothed and extrapolated 7-day utilization at the forecast horizon.
+    let projected7d: Double
+
+    /// Lower bound of the 90 % prediction interval for the 5-hour forecast.
+    let lowerBound5h: Double
+    /// Upper bound of the 90 % prediction interval for the 5-hour forecast.
+    let upperBound5h: Double
+
+    /// Lower bound of the 90 % prediction interval for the 7-day forecast.
+    let lowerBound7d: Double
+    /// Upper bound of the 90 % prediction interval for the 7-day forecast.
+    let upperBound7d: Double
+
+    /// Instantaneous rate of change of 5-hour utilization, positive = increasing. (%/hour)
+    let velocity5h: Double
+    /// Instantaneous rate of change of 7-day utilization, positive = increasing. (%/hour)
+    let velocity7d: Double
+
+    /// Rate of change of `velocity5h`. (%/hour²)
+    let acceleration5h: Double
+    /// Rate of change of `velocity7d`. (%/hour²)
+    let acceleration7d: Double
+
+    /// Forecast reliability for the 5-hour metric: 0 = unreliable, 1 = high confidence.
+    let confidence5h: Double
+    /// Forecast reliability for the 7-day metric: 0 = unreliable, 1 = high confidence.
+    let confidence7d: Double
+
+    /// Characteristic memory horizon (seconds) of the model that produced the 5-hour forecast.
+    let effectiveWindow5h: TimeInterval
+    /// Characteristic memory horizon (seconds) of the model that produced the 7-day forecast.
+    let effectiveWindow7d: TimeInterval
+}
+
+// MARK: - Service
+
+/// Adaptive weighted regression forecast engine for Claude usage metrics.
+///
+/// ## Architecture
+///
+/// The pipeline for each metric (5h, 7d) runs through five stages:
+///
+///   1. **Preprocessing** – extracts history samples, converts fractions to
+///      percent, ages them in hours, and attenuates samples recorded before a
+///      detected rolling-window reset drop.
+///
+///   2. **Adaptive λ** – estimates signal volatility from a quick first-pass
+///      regression and adjusts the exponential decay constant so that memory
+///      shortens when the signal changes rapidly and lengthens when it is stable.
+///
+///   3. **WLS regression** – fits `y = α + β·t` (linear) and `y = α + β·t + γ·t²`
+///      (quadratic) using exponentially-decaying weights. `t` is hours from now,
+///      so `α` is the current smoothed estimate, `β` is velocity, and `2γ` is
+///      acceleration.
+///
+///   4. **Head / Tail ensemble** – runs two separate models at different memory
+///      horizons (head: aggressive, τ ≈ 20 min; tail: conservative, τ ≈ 8 h)
+///      and blends them with a smooth sigmoid whose mixing ratio is driven by
+///      an instability score derived from velocity, acceleration, and noise.
+///
+///   5. **Confidence** – combines regression R², effective data density, and a
+///      stability penalty into a single 0…1 score.
+///
+/// All computation is pure (no side effects, injectable `now`) for easy testing.
+final class UsageForecastService {
+
+    // -------------------------------------------------------------------------
+    // MARK: Configuration
+    // -------------------------------------------------------------------------
+
+    /// Characteristic decay time (hours) for the tail (conservative) model.
+    /// τ_tail = 8 h → λ_tail = 0.125 /h.  A sample from 8 hours ago has weight e⁻¹ ≈ 0.37.
+    private static let tauTailHours: Double = 8.0
+
+    /// Characteristic decay time (hours) for the head (aggressive) model.
+    /// τ_head = 1/3 h = 20 min → λ_head = 3.0 /h.  Samples older than ~1 h are negligible.
+    private static let tauHeadHours: Double = 1.0 / 3.0
+
+    /// Lookahead horizon for the 5-hour forecast (seconds).
+    /// 1 hour = 20 % of the 5-hour window; meaningful but not over-speculative.
+    static let horizon5hSeconds: TimeInterval = 3600
+
+    /// Lookahead horizon for the 7-day forecast (seconds).
+    /// 4 hours ≈ 2.4 % of the 7-day window; captures slow-moving trends.
+    static let horizon7dSeconds: TimeInterval = 4 * 3600
+
+    /// Minimum sample count for a statistically meaningful regression.
+    private static let minSamples: Int = 3
+
+    /// A utilization drop larger than this (%) between consecutive samples is
+    /// treated as a rolling-window expiry event.  Pre-drop samples are attenuated
+    /// to prevent them from anchoring the regression to a now-irrelevant regime.
+    private static let dropResetThreshold: Double = 20.0
+
+    /// Weight multiplier applied to samples recorded before a detected reset drop.
+    /// 0.15 ≈ 2.6 additional equivalent hours of age (at λ_tail ≈ 0.125 /h).
+    private static let preDropWeightMultiplier: Double = 0.15
+
+    // -------------------------------------------------------------------------
+    // MARK: Public API
+    // -------------------------------------------------------------------------
+
+    /// Produce a forecast from persisted usage history and the current API response.
+    ///
+    /// - Parameters:
+    ///   - history: `UsageHistory` from `UsageHistoryService` (pct values in 0–1).
+    ///   - current: Most recent `UsageResponse` from the polling API.
+    ///   - now:     Injection point for deterministic testing; defaults to `Date()`.
+    func forecast(
+        history: UsageHistory,
+        current: UsageResponse,
+        now: Date = Date()
+    ) -> UsageForecast {
+
+        let ch5h = computeChannel(
+            history: history,
+            historyKeyPath: \.pct5h,
+            currentUtilization: current.fiveHour?.utilization,
+            horizon: Self.horizon5hSeconds,
+            tauHead: Self.tauHeadHours,
+            tauTail: Self.tauTailHours,
+            now: now
+        )
+
+        let ch7d = computeChannel(
+            history: history,
+            historyKeyPath: \.pct7d,
+            currentUtilization: current.sevenDay?.utilization,
+            horizon: Self.horizon7dSeconds,
+            tauHead: Self.tauHeadHours,
+            tauTail: Self.tauTailHours,
+            now: now
+        )
+
+        func predictionInterval(_ ch: ChannelResult) -> (lower: Double, upper: Double) {
+            // 90 % prediction interval: ±1.645σ.  The band is divided by confidence
+            // so that low-confidence forecasts produce wider intervals automatically.
+            // At confidence = 1.0 the band is ±1.645σ; at confidence = 0.2 it is ±8.2σ.
+            let halfWidth = ch.residualStd * 1.645 / max(0.1, ch.confidence)
+            return (
+                (ch.projected - halfWidth).clamped(to: 0...100),
+                (ch.projected + halfWidth).clamped(to: 0...100)
+            )
+        }
+
+        let iv5h = predictionInterval(ch5h)
+        let iv7d = predictionInterval(ch7d)
+
+        return UsageForecast(
+            projected5h:    ch5h.projected.clamped(to: 0...100),
+            projected7d:    ch7d.projected.clamped(to: 0...100),
+            lowerBound5h:   iv5h.lower,
+            upperBound5h:   iv5h.upper,
+            lowerBound7d:   iv7d.lower,
+            upperBound7d:   iv7d.upper,
+            velocity5h:     ch5h.velocity,
+            velocity7d:     ch7d.velocity,
+            acceleration5h: ch5h.acceleration,
+            acceleration7d: ch7d.acceleration,
+            confidence5h:   ch5h.confidence,
+            confidence7d:   ch7d.confidence,
+            effectiveWindow5h: ch5h.effectiveWindow,
+            effectiveWindow7d: ch7d.effectiveWindow
+        )
+    }
+}
+
+// -------------------------------------------------------------------------
+// MARK: Internal Types
+// -------------------------------------------------------------------------
+
+private extension UsageForecastService {
+
+    /// A preprocessed, age-weighted observation.
+    struct Sample {
+        /// Time from now in hours; always ≤ 0 (past).  `t = 0` is the current moment.
+        let t: Double
+        /// Utilization in percent (0–100).
+        let value: Double
+        /// Extra weight scaling on top of the exponential decay.
+        /// Set to `preDropWeightMultiplier` for samples before a detected reset drop;
+        /// 1.0 otherwise.  This is lambda-independent, unlike shifting `t`.
+        let weightMultiplier: Double
+
+        /// Age in hours (≥ 0).  Used to compute `exp(-λ · age)`.
+        var age: Double { -t }
+    }
+
+    /// Result of a 2-parameter weighted least-squares fit:  y = α + β·t.
+    struct LinearFit {
+        /// Estimated utilization at t = 0 (right now), %.
+        let alpha: Double
+        /// Slope: rate of change at t = 0, %/hour.  Positive = utilization is rising.
+        let beta: Double
+        /// Coefficient of determination (0–1).  Higher = better fit.
+        let rSquared: Double
+        /// Weighted mean-squared residual, %².  Square-root gives residual std.
+        let residualVariance: Double
+        /// Effective sample count: (Σw)² / Σ(w²).  Accounts for downweighting.
+        let effectiveN: Double
+    }
+
+    /// Result of a 3-parameter weighted least-squares fit:  y = α + β·t + γ·t².
+    struct QuadraticFit {
+        /// Estimated utilization at t = 0, %.
+        let alpha: Double
+        /// Velocity at t = 0: dy/dt |_{t=0} = β, %/hour.
+        let beta: Double
+        /// Half-curvature coefficient.  Acceleration = 2γ, %/hour².
+        let gamma: Double
+        /// `false` when the 3×3 system was (near-)singular; model falls back to linear.
+        let valid: Bool
+
+        var acceleration: Double { 2.0 * gamma }  // %/hour²
+    }
+
+    /// Fully-blended result for one usage channel (5h or 7d).
+    struct ChannelResult {
+        let projected: Double          // %
+        let velocity: Double           // %/hour
+        let acceleration: Double       // %/hour²
+        let confidence: Double         // 0…1
+        let effectiveWindow: TimeInterval  // seconds
+        let residualStd: Double        // %
+    }
+}
+
+// -------------------------------------------------------------------------
+// MARK: Pipeline
+// -------------------------------------------------------------------------
+
+private extension UsageForecastService {
+
+    /// Run the full forecast pipeline for one utilization channel.
+    func computeChannel(
+        history: UsageHistory,
+        historyKeyPath: KeyPath<UsageDataPoint, Double>,
+        currentUtilization: Double?,
+        horizon: TimeInterval,
+        tauHead: Double,
+        tauTail: Double,
+        now: Date
+    ) -> ChannelResult {
+
+        let samples = preprocessSamples(
+            history: history,
+            historyKeyPath: historyKeyPath,
+            currentUtilization: currentUtilization,
+            now: now
+        )
+
+        // Degenerate case: too few samples for meaningful regression.
+        guard samples.count >= Self.minSamples else {
+            let value = (currentUtilization ?? 0).clamped(to: 0...100)
+            let tau   = (tauHead + tauTail) / 2
+            return ChannelResult(
+                projected:       value,
+                velocity:        0,
+                acceleration:    0,
+                confidence:      max(0.05, Double(samples.count) * 0.03),
+                effectiveWindow: tau * 3600,
+                residualStd:     max(1.0, value * 0.1)
+            )
+        }
+
+        let horizonHours = horizon / 3600
+
+        // --- Head model: aggressive, short-memory, tracks recent spikes ---
+        let lambdaHead = adaptLambda(base: 1.0 / tauHead, samples: samples)
+        let head = fitAndProject(samples: samples, lambda: lambdaHead, horizonHours: horizonHours)
+
+        // --- Tail model: conservative, long-memory, anchors to sustained trend ---
+        let lambdaTail = adaptLambda(base: 1.0 / tauTail, samples: samples)
+        let tail = fitAndProject(samples: samples, lambda: lambdaTail, horizonHours: horizonHours)
+
+        // --- Ensemble blend via smooth sigmoid ---
+        // Instability score from the head model (more sensitive to recent changes).
+        // At instability ≈ 0 the tail dominates (sigmoid ≈ 0.1).
+        // At instability ≈ 2 the head dominates (sigmoid ≈ 0.88).
+        // Midpoint at instability = 1.0, steepness = 3: the transition spans roughly
+        // [0.2, 1.8] and avoids any hard threshold.
+        let instability = computeInstabilityScore(
+            velocity:     head.velocity,
+            acceleration: head.acceleration,
+            residualStd:  head.residualStd
+        )
+        let w = sigmoid(instability, midpoint: 1.0, steepness: 3.0)
+
+        let projected    = w * head.projected    + (1 - w) * tail.projected
+        let velocity     = w * head.velocity     + (1 - w) * tail.velocity
+        let acceleration = w * head.acceleration + (1 - w) * tail.acceleration
+        let residualStd  = w * head.residualStd  + (1 - w) * tail.residualStd
+
+        // Blend confidences, then apply a stability bonus:
+        // the more volatile the signal, the harder it is to forecast reliably.
+        let blendedConf = w * head.confidence + (1 - w) * tail.confidence
+        let confidence  = (blendedConf * exp(-instability * 0.3)).clamped(to: 0...1)
+
+        // Effective memory horizon from the blended decay constant.
+        let lambdaBlended  = w * lambdaHead + (1 - w) * lambdaTail
+        let effectiveWindow = (1.0 / max(lambdaBlended, 1e-6)) * 3600  // hours⁻¹ → seconds
+
+        return ChannelResult(
+            projected:       projected,
+            velocity:        velocity,
+            acceleration:    acceleration,
+            confidence:      confidence,
+            effectiveWindow: effectiveWindow,
+            residualStd:     residualStd
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // MARK: Stage 1 – Preprocessing
+    // -------------------------------------------------------------------------
+
+    /// Build a sorted, scaled sample array from raw history and the current reading.
+    ///
+    /// Steps:
+    ///   1. Convert history `pct` values (stored as 0–1 fractions) to percent.
+    ///   2. Append the current API utilization as the freshest sample at t = 0.
+    ///   3. Drop samples older than 7 days (beyond even the tail's lookback).
+    ///   4. Sort chronologically (oldest first, t most negative → t = 0).
+    ///   5. Detect rolling-window reset drops and attenuate pre-drop samples via
+    ///      `weightMultiplier`; this isolates the regression to the post-reset regime.
+    func preprocessSamples(
+        history: UsageHistory,
+        historyKeyPath: KeyPath<UsageDataPoint, Double>,
+        currentUtilization: Double?,
+        now: Date
+    ) -> [Sample] {
+
+        let maxLookbackHours: Double = 7.0 * 24.0
+
+        // Collect raw (t_hours, value_pct) tuples from the persisted history.
+        var rawPairs: [(t: Double, value: Double)] = history.dataPoints.compactMap { point in
+            let ageHours = now.timeIntervalSince(point.timestamp) / 3600.0
+            guard ageHours >= 0, ageHours <= maxLookbackHours else { return nil }
+            return (-ageHours, point[keyPath: historyKeyPath] * 100.0)  // fraction → %
+        }
+
+        // Inject the current API reading as a sample exactly at t = 0.
+        if let u = currentUtilization {
+            rawPairs.append((0.0, u.clamped(to: 0...100)))
+        }
+
+        guard !rawPairs.isEmpty else { return [] }
+
+        rawPairs.sort { $0.t < $1.t }  // oldest (most negative t) first
+
+        // --- Rolling-window reset detection ---
+        //
+        // Claude's utilization windows are rolling: old usage falls out of the
+        // window progressively.  A sharp downward jump — larger than
+        // `dropResetThreshold` % between consecutive samples — typically marks
+        // the moment a cluster of old high-usage requests aged out.
+        //
+        // After such an event the prior trend is misleading: if we kept
+        // pre-drop samples at full weight, the regression would fit a phantom
+        // downtrend and underestimate utilization.
+        //
+        // Strategy: find the most recent drop event and multiply the weight of
+        // all samples recorded before it by `preDropWeightMultiplier`.  We use
+        // the most recent drop (not the first) to handle multiple partial resets.
+        var dropBoundaryIndex: Int? = nil
+        for i in 1 ..< rawPairs.count {
+            let delta = rawPairs[i].value - rawPairs[i - 1].value
+            if delta < -Self.dropResetThreshold {
+                dropBoundaryIndex = i  // update to always use the latest drop
+            }
+        }
+
+        return rawPairs.enumerated().map { idx, pair in
+            let multiplier: Double
+            if let boundary = dropBoundaryIndex, idx < boundary {
+                multiplier = Self.preDropWeightMultiplier
+            } else {
+                multiplier = 1.0
+            }
+            return Sample(t: pair.t, value: pair.value, weightMultiplier: multiplier)
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // MARK: Stage 2 – Adaptive λ
+    // -------------------------------------------------------------------------
+
+    /// Adapt the exponential decay constant based on the signal's current volatility.
+    ///
+    /// Algorithm:
+    ///   1. Run a quick first-pass regression at `base` λ.
+    ///   2. Compute an instability score from velocity, acceleration, and residual noise.
+    ///   3. Scale λ by `exp(instability / 2)`:
+    ///        - stable   (instability → 0): scale ≈ 1.0  → memory unchanged
+    ///        - moderate (instability = 1): scale ≈ 1.65 → 65 % shorter memory
+    ///        - volatile (instability = 2): scale ≈ 2.7  → 2.7× shorter memory
+    ///   4. Clamp to [0.5×, 20×] base to prevent pathological forgetting or over-retention.
+    func adaptLambda(base lambda0: Double, samples: [Sample]) -> Double {
+        let linearFit = weightedLinearRegression(samples: samples, lambda: lambda0)
+        let quadFit   = weightedQuadraticRegression(samples: samples, lambda: lambda0, linearFallback: linearFit)
+
+        let instability = computeInstabilityScore(
+            velocity:     quadFit.valid ? quadFit.beta        : linearFit.beta,
+            acceleration: quadFit.valid ? quadFit.acceleration : 0,
+            residualStd:  sqrt(max(0, linearFit.residualVariance))
+        )
+
+        let scale = exp(instability / 2.0).clamped(to: 0.5...20.0)
+        return lambda0 * scale
+    }
+
+    // -------------------------------------------------------------------------
+    // MARK: Stage 3 – Fit & Project
+    // -------------------------------------------------------------------------
+
+    /// Fit both linear and quadratic WLS models, extrapolate to `horizonHours`,
+    /// and return the blended result with velocity, acceleration, and confidence.
+    func fitAndProject(samples: [Sample], lambda: Double, horizonHours: Double) -> ChannelResult {
+        let linear = weightedLinearRegression(samples: samples, lambda: lambda)
+        let quad   = weightedQuadraticRegression(samples: samples, lambda: lambda, linearFallback: linear)
+
+        // Extrapolate each model to the forecast horizon.
+        let h = horizonHours
+        let projLinear = linear.alpha + linear.beta * h
+        let projQuad   = quad.valid
+            ? quad.alpha + quad.beta * h + quad.gamma * h * h
+            : projLinear
+
+        // Blend linear and quadratic projections, weighting quadratic conservatively.
+        // The quadratic contribution grows with R² (better fit = more curvature trusted)
+        // but is capped at 35 % to avoid overfitting, especially with sparse data.
+        // With only 3 samples the quadratic nearly passes through every point, making
+        // its extrapolation unreliable beyond a short horizon.
+        let quadWeight = (linear.rSquared * 0.35).clamped(to: 0...0.35)
+        let projected  = (1 - quadWeight) * projLinear + quadWeight * projQuad
+
+        // Velocity and acceleration from the quadratic when it converged.
+        let velocity     = quad.valid ? quad.beta        : linear.beta
+        let acceleration = quad.valid ? quad.acceleration : 0.0
+
+        let confidence = computeConfidence(linearFit: linear, velocity: velocity, acceleration: acceleration)
+        let residualStd = sqrt(max(0, linear.residualVariance))
+
+        let effectiveWindow = (1.0 / max(lambda, 1e-6)) * 3600  // hours⁻¹ → seconds
+
+        return ChannelResult(
+            projected:       projected,
+            velocity:        velocity,
+            acceleration:    acceleration,
+            confidence:      confidence,
+            effectiveWindow: effectiveWindow,
+            residualStd:     residualStd
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // MARK: WLS Linear Regression:  y = α + β·t
+    // -------------------------------------------------------------------------
+
+    /// Weighted least-squares linear regression with exponential sample weights.
+    ///
+    /// **Weight for sample i:**
+    ///   w_i = exp(−λ · age_i) · weightMultiplier_i
+    ///   where age_i = −t_i ≥ 0 (hours since sample was recorded).
+    ///
+    /// **WLS normal equations** (Σ denotes weighted sum):
+    ///
+    ///   ┌ Σw    Σwt  ┐ ┌ α ┐   ┌ Σwy  ┐
+    ///   │             │ │   │ = │      │
+    ///   └ Σwt   Σwt² ┘ └ β ┘   └ Σwty ┘
+    ///
+    /// **Closed-form solution (Cramer's rule):**
+    ///   det = Σw · Σwt² − (Σwt)²
+    ///   α   = (Σwy · Σwt² − Σwty · Σwt) / det
+    ///   β   = (Σw  · Σwty − Σwt  · Σwy) / det
+    ///
+    /// When det ≈ 0 (all samples at the same time-point, or a single sample)
+    /// the system is singular; we fall back to the weighted mean with zero slope.
+    ///
+    /// **Interpretation:**
+    ///   - α: smoothed utilization estimate *right now* (t = 0), %.
+    ///   - β: instantaneous velocity at t = 0, %/hour.
+    func weightedLinearRegression(samples: [Sample], lambda: Double) -> LinearFit {
+        var Sw   = 0.0, Swt = 0.0, Swtt = 0.0
+        var Swy  = 0.0, Swty = 0.0
+        var Sw2  = 0.0  // Σw² for effective-N calculation
+
+        for s in samples {
+            let w  = exp(-lambda * s.age) * s.weightMultiplier
+            let t  = s.t
+            let y  = s.value
+            Sw   += w
+            Swt  += w * t
+            Swtt += w * t * t
+            Swy  += w * y
+            Swty += w * t * y
+            Sw2  += w * w
+        }
+
+        guard Sw > 1e-12 else {
+            return LinearFit(alpha: 0, beta: 0, rSquared: 0, residualVariance: 0, effectiveN: 0)
+        }
+
+        let det = Sw * Swtt - Swt * Swt
+
+        let alpha: Double
+        let beta: Double
+        if abs(det) < 1e-10 {
+            // Singular (e.g. all samples at the same t).  Weighted mean, zero slope.
+            alpha = Swy / Sw
+            beta  = 0
+        } else {
+            alpha = (Swy * Swtt - Swty * Swt) / det
+            beta  = (Sw  * Swty - Swt  * Swy) / det
+        }
+
+        // --- Goodness of fit ---
+        let yMean = Swy / Sw
+        var SS_res = 0.0, SS_tot = 0.0
+
+        for s in samples {
+            let w      = exp(-lambda * s.age) * s.weightMultiplier
+            let fitted = alpha + beta * s.t
+            let resid  = s.value - fitted
+            SS_res += w * resid * resid
+            SS_tot += w * (s.value - yMean) * (s.value - yMean)
+        }
+
+        let rSquared        = SS_tot < 1e-12 ? 1.0 : max(0, 1.0 - SS_res / SS_tot)
+        let residualVariance = SS_res / Sw         // weighted MSE
+        let effectiveN       = Sw2 < 1e-12 ? 0 : (Sw * Sw) / Sw2
+
+        return LinearFit(
+            alpha:            alpha,
+            beta:             beta,
+            rSquared:         rSquared,
+            residualVariance: residualVariance,
+            effectiveN:       effectiveN
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // MARK: WLS Quadratic Regression:  y = α + β·t + γ·t²
+    // -------------------------------------------------------------------------
+
+    /// Weighted least-squares quadratic regression.
+    ///
+    /// **WLS normal equations** (3×3 system):
+    ///
+    ///   ┌ Σw    Σwt    Σwt²   ┐ ┌ α ┐   ┌ Σwy   ┐
+    ///   │ Σwt   Σwt²   Σwt³   │ │ β │ = │ Σwty  │
+    ///   └ Σwt²  Σwt³   Σwt⁴  ┘ └ γ ┘   └ Σwt²y ┘
+    ///
+    /// Solved by **Gaussian elimination with partial pivoting** to maximise
+    /// numerical stability with the varying magnitudes produced by different λ values.
+    ///
+    /// Falls back to `linearFallback` when:
+    ///   - fewer than 4 samples are available (the quadratic would be under-constrained),
+    ///   - the pivot is too small (system is singular — e.g. all values identical), or
+    ///   - the estimated curvature |γ| exceeds a physical sanity bound.
+    ///
+    /// **Interpretation:**
+    ///   - β = velocity at t = 0 (%/hour)
+    ///   - 2γ = acceleration (%/hour²); positive γ → usage is accelerating upward
+    func weightedQuadraticRegression(
+        samples: [Sample],
+        lambda: Double,
+        linearFallback: LinearFit
+    ) -> QuadraticFit {
+
+        // Quadratic needs at least 4 samples to be more informative than linear.
+        guard samples.count >= 4 else {
+            return QuadraticFit(alpha: linearFallback.alpha, beta: linearFallback.beta, gamma: 0, valid: false)
+        }
+
+        var Sw    = 0.0
+        var Swt   = 0.0, Swtt   = 0.0, Swttt  = 0.0, Swtttt = 0.0
+        var Swy   = 0.0, Swty   = 0.0, Swtty  = 0.0
+
+        for s in samples {
+            let w  = exp(-lambda * s.age) * s.weightMultiplier
+            let t  = s.t
+            let t2 = t * t
+            let t3 = t2 * t
+            let t4 = t3 * t
+            let y  = s.value
+
+            Sw     += w
+            Swt    += w * t
+            Swtt   += w * t2
+            Swttt  += w * t3
+            Swtttt += w * t4
+            Swy    += w * y
+            Swty   += w * t * y
+            Swtty  += w * t2 * y
+        }
+
+        // Augmented matrix [A | b] — 3 rows × 4 columns.
+        var M: [[Double]] = [
+            [Sw,    Swt,    Swtt,   Swy  ],
+            [Swt,   Swtt,   Swttt,  Swty ],
+            [Swtt,  Swttt,  Swtttt, Swtty]
+        ]
+
+        // Gaussian elimination with partial pivoting.
+        for col in 0 ..< 3 {
+            var pivotRow = col
+            var pivotMag = abs(M[col][col])
+            for row in (col + 1) ..< 3 where abs(M[row][col]) > pivotMag {
+                pivotMag = abs(M[row][col])
+                pivotRow = row
+            }
+            guard pivotMag > 1e-10 else {
+                return QuadraticFit(alpha: linearFallback.alpha, beta: linearFallback.beta, gamma: 0, valid: false)
+            }
+            if pivotRow != col { M.swapAt(col, pivotRow) }
+            let pivot = M[col][col]
+            for row in (col + 1) ..< 3 {
+                let f = M[row][col] / pivot
+                for c in col ..< 4 { M[row][c] -= f * M[col][c] }
+            }
+        }
+
+        // Back substitution.
+        var x = [Double](repeating: 0, count: 3)
+        for row in stride(from: 2, through: 0, by: -1) {
+            guard abs(M[row][row]) > 1e-14 else {
+                return QuadraticFit(alpha: linearFallback.alpha, beta: linearFallback.beta, gamma: 0, valid: false)
+            }
+            var sum = M[row][3]
+            for c in (row + 1) ..< 3 { sum -= M[row][c] * x[c] }
+            x[row] = sum / M[row][row]
+        }
+
+        // Sanity clamp: |γ| > 200 %/h² would mean going from 0 % to 100 % in under
+        // a minute — physically impossible given Claude's rolling window mechanics.
+        // Such values indicate an over-fitted quadratic on noisy sparse data.
+        guard abs(x[2]) <= 200 else {
+            return QuadraticFit(alpha: linearFallback.alpha, beta: linearFallback.beta, gamma: 0, valid: false)
+        }
+
+        return QuadraticFit(alpha: x[0], beta: x[1], gamma: x[2], valid: true)
+    }
+
+    // -------------------------------------------------------------------------
+    // MARK: Stage 5 – Confidence
+    // -------------------------------------------------------------------------
+
+    /// Derive forecast confidence from three orthogonal components.
+    ///
+    /// **R² component** (0–1):
+    ///   Measures how well the linear model explains the observed variance.
+    ///   A noisy, erratic signal yields a low R², indicating unreliable extrapolation.
+    ///
+    /// **Density component** (0–1):
+    ///   `log(1 + n_eff) / log(1 + 10)`
+    ///   Saturates at n_eff ≈ 10 effective samples.  Uses the log scale because
+    ///   going from 1 to 3 samples matters far more than going from 30 to 32.
+    ///
+    /// **Stability component** (0–1):
+    ///   `exp(−|v|/50 − |a|/10)`
+    ///   High velocity and acceleration mean the signal is extrapolating aggressively
+    ///   into uncertain territory.  Reference scales: 50 %/h for velocity ("fast"),
+    ///   10 %/h² for acceleration ("rapidly accelerating").
+    ///
+    /// The three components are **multiplied** together so that a single very bad
+    /// factor (e.g. only 1 sample, or R² = 0.02) tanks the overall score.
+    func computeConfidence(linearFit: LinearFit, velocity: Double, acceleration: Double) -> Double {
+        let r2Component = linearFit.rSquared.clamped(to: 0...1)
+
+        let densityComponent = (log(1 + linearFit.effectiveN) / log(1 + 10)).clamped(to: 0...1)
+
+        let stabilityComponent = exp(-abs(velocity) / 50.0 - abs(acceleration) / 10.0)
+
+        return (r2Component * densityComponent * stabilityComponent).clamped(to: 0...1)
+    }
+
+    // -------------------------------------------------------------------------
+    // MARK: Instability Score
+    // -------------------------------------------------------------------------
+
+    /// Scalar instability score used for adaptive λ and ensemble blending.
+    ///
+    /// Normalised to natural reference magnitudes:
+    ///   velocity:    50 %/h  (= 0→100 % in 2 hours)
+    ///   acceleration: 10 %/h² (= doubling rate per hour)
+    ///   noise:        10 % std (typical polling jitter)
+    ///
+    /// Score ≈ 0: stable, long-memory regime.
+    /// Score ≈ 1: moderately volatile — head and tail begin to diverge.
+    /// Score ≥ 2: rapid change — recent observations dominate.
+    func computeInstabilityScore(velocity: Double, acceleration: Double, residualStd: Double) -> Double {
+        let v = abs(velocity)    / 50.0
+        let a = abs(acceleration) / 10.0
+        let n = residualStd      / 10.0
+        // Acceleration and noise are weighted higher because they indicate
+        // structural change in the signal, not just a sustained trend.
+        return (v * 0.5 + a * 1.0 + n * 0.5).clamped(to: 0...10)
+    }
+
+    // -------------------------------------------------------------------------
+    // MARK: Sigmoid
+    // -------------------------------------------------------------------------
+
+    /// Smooth sigmoid function for continuously blending two models.
+    ///
+    /// Returns ≈ 0 when `x << midpoint` (tail dominates) and ≈ 1 when
+    /// `x >> midpoint` (head dominates).  `steepness` controls the sharpness of
+    /// the transition without introducing any hard threshold.
+    func sigmoid(_ x: Double, midpoint: Double, steepness: Double) -> Double {
+        1.0 / (1.0 + exp(-steepness * (x - midpoint)))
+    }
+}
+
+// -------------------------------------------------------------------------
+// MARK: Double Clamping
+// -------------------------------------------------------------------------
+
+private extension Double {
+    func clamped(to range: ClosedRange<Double>) -> Double {
+        Swift.min(Swift.max(self, range.lowerBound), range.upperBound)
+    }
+}

--- a/macos/Sources/ClaudeUsageBar/UsageHistoryService.swift
+++ b/macos/Sources/ClaudeUsageBar/UsageHistoryService.swift
@@ -1,17 +1,13 @@
 import Foundation
-import Combine
 import AppKit
 
 @MainActor
 class UsageHistoryService: ObservableObject {
     @Published var history = UsageHistory()
 
-    private var flushTimer: AnyCancellable?
-    private var isDirty = false
     private var terminationObserver: Any?
 
     private static let retentionInterval: TimeInterval = 30 * 86400 // 30 days
-    private static let flushInterval: TimeInterval = 300 // 5 minutes
 
     private static var historyFileURL: URL {
         let dir = FileManager.default.homeDirectoryForCurrentUser
@@ -63,31 +59,16 @@ class UsageHistoryService: ObservableObject {
     func recordDataPoint(pct5h: Double, pct7d: Double) {
         let point = UsageDataPoint(pct5h: pct5h, pct7d: pct7d)
         history.dataPoints.append(point)
-        isDirty = true
-        startFlushTimerIfNeeded()
+        flushToDisk()
     }
 
     // MARK: - Flush
 
     func flushToDisk() {
-        guard isDirty else { return }
         history.dataPoints = pruned(history.dataPoints)
 
         guard let data = try? JSONEncoder.historyEncoder.encode(history) else { return }
         try? data.write(to: Self.historyFileURL, options: .atomic)
-
-        isDirty = false
-        flushTimer?.cancel()
-        flushTimer = nil
-    }
-
-    private func startFlushTimerIfNeeded() {
-        guard flushTimer == nil else { return }
-        flushTimer = Timer.publish(every: Self.flushInterval, on: .main, in: .common)
-            .autoconnect()
-            .sink { [weak self] _ in
-                self?.flushToDisk()
-            }
     }
 
     // MARK: - Downsampling

--- a/macos/Sources/ClaudeUsageBar/UsageService.swift
+++ b/macos/Sources/ClaudeUsageBar/UsageService.swift
@@ -5,6 +5,7 @@ import AppKit
 @MainActor
 class UsageService: ObservableObject {
     @Published var usage: UsageResponse?
+    @Published var forecast: UsageForecast?
     @Published var lastError: String?
     @Published var lastUpdated: Date?
     @Published var isAuthenticated = false
@@ -13,6 +14,8 @@ class UsageService: ObservableObject {
 
     var historyService: UsageHistoryService?
     var notificationService: NotificationService?
+
+    private let forecastService = UsageForecastService()
 
     private var timer: Timer?
     private let session: URLSession
@@ -289,6 +292,9 @@ class UsageService: ObservableObject {
             lastError = nil
             lastUpdated = Date()
             historyService?.recordDataPoint(pct5h: pct5h, pct7d: pct7d)
+            if let history = historyService?.history {
+                forecast = forecastService.forecast(history: history, current: reconciled)
+            }
             notificationService?.checkAndNotify(pct5h: pct5h, pct7d: pct7d, pctExtra: pctExtra)
             if currentInterval != baseInterval {
                 currentInterval = baseInterval

--- a/macos/Tests/ClaudeUsageBarTests/UsageForecastServiceTests.swift
+++ b/macos/Tests/ClaudeUsageBarTests/UsageForecastServiceTests.swift
@@ -1,0 +1,254 @@
+import XCTest
+@testable import ClaudeUsageBar
+
+final class UsageForecastServiceTests: XCTestCase {
+
+    private let service = UsageForecastService()
+    private let now = Date(timeIntervalSince1970: 1_000_000)
+
+    // MARK: - Helpers
+
+    /// Build a UsageHistory from (hoursAgo, pct5h%, pct7d%) tuples.
+    /// pct values are in 0–100 and stored internally as fractions, matching UsageHistoryService.
+    private func makeHistory(_ readings: [(hoursAgo: Double, pct5h: Double, pct7d: Double)]) -> UsageHistory {
+        var history = UsageHistory()
+        history.dataPoints = readings.map { r in
+            UsageDataPoint(
+                timestamp: now.addingTimeInterval(-r.hoursAgo * 3600),
+                pct5h: r.pct5h / 100.0,
+                pct7d: r.pct7d / 100.0
+            )
+        }
+        return history
+    }
+
+    private func makeResponse(fiveHour: Double? = nil, sevenDay: Double? = nil) -> UsageResponse {
+        UsageResponse(
+            fiveHour:      fiveHour.map { UsageBucket(utilization: $0, resetsAt: nil) },
+            sevenDay:      sevenDay.map { UsageBucket(utilization: $0, resetsAt: nil) },
+            sevenDayOpus:  nil,
+            sevenDaySonnet: nil,
+            extraUsage:    nil
+        )
+    }
+
+    // MARK: - Fallback path (< minSamples)
+
+    func testForecastReturnsFallbackWhenHistoryIsEmpty() {
+        let forecast = service.forecast(
+            history: UsageHistory(),
+            current: makeResponse(fiveHour: 40, sevenDay: 60),
+            now: now
+        )
+        // With 1 total sample the service can't regress; it echoes the current value.
+        XCTAssertEqual(forecast.projected5h, 40, accuracy: 0.01)
+        XCTAssertEqual(forecast.projected7d, 60, accuracy: 0.01)
+        XCTAssertLessThan(forecast.confidence5h, 0.2)
+        XCTAssertLessThan(forecast.confidence7d, 0.2)
+    }
+
+    func testForecastReturnsFallbackWithOnlyOneHistorySample() {
+        // 1 history + 1 current = 2 samples; minSamples = 3 → fallback
+        let history = makeHistory([(hoursAgo: 2, pct5h: 30, pct7d: 50)])
+        let forecast = service.forecast(
+            history: history,
+            current: makeResponse(fiveHour: 35, sevenDay: 55),
+            now: now
+        )
+        XCTAssertEqual(forecast.projected5h, 35, accuracy: 1.0)
+        XCTAssertLessThan(forecast.confidence5h, 0.2)
+    }
+
+    // MARK: - Trend projection
+
+    func testForecastProjectsRisingTrend() {
+        let history = makeHistory([
+            (hoursAgo: 4, pct5h: 10, pct7d: 10),
+            (hoursAgo: 3, pct5h: 20, pct7d: 20),
+            (hoursAgo: 2, pct5h: 30, pct7d: 30),
+            (hoursAgo: 1, pct5h: 40, pct7d: 40),
+        ])
+        let forecast = service.forecast(
+            history: history,
+            current: makeResponse(fiveHour: 50, sevenDay: 50),
+            now: now
+        )
+        XCTAssertGreaterThan(forecast.projected5h, 50)
+        XCTAssertGreaterThan(forecast.velocity5h, 0)
+        XCTAssertGreaterThan(forecast.projected7d, 50)
+        XCTAssertGreaterThan(forecast.velocity7d, 0)
+    }
+
+    func testForecastProjectsFallingTrend() {
+        let history = makeHistory([
+            (hoursAgo: 4, pct5h: 80, pct7d: 80),
+            (hoursAgo: 3, pct5h: 70, pct7d: 70),
+            (hoursAgo: 2, pct5h: 60, pct7d: 60),
+            (hoursAgo: 1, pct5h: 50, pct7d: 50),
+        ])
+        let forecast = service.forecast(
+            history: history,
+            current: makeResponse(fiveHour: 40, sevenDay: 40),
+            now: now
+        )
+        XCTAssertLessThan(forecast.projected5h, 40)
+        XCTAssertLessThan(forecast.velocity5h, 0)
+        XCTAssertLessThan(forecast.projected7d, 40)
+        XCTAssertLessThan(forecast.velocity7d, 0)
+    }
+
+    func testForecastIsStableForFlatSignal() {
+        let history = makeHistory([
+            (hoursAgo: 5, pct5h: 50, pct7d: 30),
+            (hoursAgo: 4, pct5h: 50, pct7d: 30),
+            (hoursAgo: 3, pct5h: 50, pct7d: 30),
+            (hoursAgo: 2, pct5h: 50, pct7d: 30),
+            (hoursAgo: 1, pct5h: 50, pct7d: 30),
+        ])
+        let forecast = service.forecast(
+            history: history,
+            current: makeResponse(fiveHour: 50, sevenDay: 30),
+            now: now
+        )
+        XCTAssertEqual(forecast.projected5h, 50, accuracy: 2.0)
+        XCTAssertEqual(forecast.velocity5h,   0, accuracy: 1.0)
+        XCTAssertEqual(forecast.projected7d, 30, accuracy: 2.0)
+        XCTAssertEqual(forecast.velocity7d,   0, accuracy: 1.0)
+    }
+
+    // MARK: - Output clamping
+
+    func testForecastClampsProjectionAboveZero() {
+        // Steep downward trend ending at 0 — unclamped WLS would extrapolate negative.
+        let history = makeHistory([
+            (hoursAgo: 4, pct5h: 20, pct7d: 20),
+            (hoursAgo: 3, pct5h: 10, pct7d: 10),
+            (hoursAgo: 2, pct5h:  5, pct7d:  5),
+            (hoursAgo: 1, pct5h:  2, pct7d:  2),
+        ])
+        let forecast = service.forecast(
+            history: history,
+            current: makeResponse(fiveHour: 0, sevenDay: 0),
+            now: now
+        )
+        XCTAssertGreaterThanOrEqual(forecast.projected5h,  0)
+        XCTAssertGreaterThanOrEqual(forecast.lowerBound5h, 0)
+        XCTAssertGreaterThanOrEqual(forecast.projected7d,  0)
+        XCTAssertGreaterThanOrEqual(forecast.lowerBound7d, 0)
+    }
+
+    func testForecastClampsProjectionBelowHundred() {
+        // Steep upward trend ending at 100 — unclamped WLS would extrapolate above 100.
+        let history = makeHistory([
+            (hoursAgo: 4, pct5h: 60, pct7d: 60),
+            (hoursAgo: 3, pct5h: 75, pct7d: 75),
+            (hoursAgo: 2, pct5h: 85, pct7d: 85),
+            (hoursAgo: 1, pct5h: 95, pct7d: 95),
+        ])
+        let forecast = service.forecast(
+            history: history,
+            current: makeResponse(fiveHour: 100, sevenDay: 100),
+            now: now
+        )
+        XCTAssertLessThanOrEqual(forecast.projected5h,  100)
+        XCTAssertLessThanOrEqual(forecast.upperBound5h, 100)
+        XCTAssertLessThanOrEqual(forecast.projected7d,  100)
+        XCTAssertLessThanOrEqual(forecast.upperBound7d, 100)
+    }
+
+    // MARK: - Reset drop detection
+
+    func testForecastAttenuatesPreDropSamples() {
+        // High usage, then a >20% drop.  Pre-drop samples should be down-weighted
+        // so the forecast follows the post-drop regime, not the pre-drop high.
+        let history = makeHistory([
+            (hoursAgo: 5, pct5h: 90, pct7d: 90),
+            (hoursAgo: 4, pct5h: 88, pct7d: 88),
+            (hoursAgo: 3, pct5h: 85, pct7d: 85),
+            (hoursAgo: 2, pct5h: 10, pct7d: 10),  // >20% drop — reset event
+            (hoursAgo: 1, pct5h: 12, pct7d: 12),
+        ])
+        let forecast = service.forecast(
+            history: history,
+            current: makeResponse(fiveHour: 15, sevenDay: 15),
+            now: now
+        )
+        XCTAssertLessThan(forecast.projected5h, 50,
+            "Forecast should reflect post-drop regime (~15%), not the pre-drop high (~88%)")
+    }
+
+    // MARK: - Determinism
+
+    func testForecastIsDeterministicWithInjectedNow() {
+        let history = makeHistory([
+            (hoursAgo: 3, pct5h: 20, pct7d: 30),
+            (hoursAgo: 2, pct5h: 30, pct7d: 35),
+            (hoursAgo: 1, pct5h: 40, pct7d: 40),
+        ])
+        let current = makeResponse(fiveHour: 50, sevenDay: 45)
+        let a = service.forecast(history: history, current: current, now: now)
+        let b = service.forecast(history: history, current: current, now: now)
+        XCTAssertEqual(a.projected5h,   b.projected5h)
+        XCTAssertEqual(a.projected7d,   b.projected7d)
+        XCTAssertEqual(a.velocity5h,    b.velocity5h)
+        XCTAssertEqual(a.confidence5h,  b.confidence5h)
+        XCTAssertEqual(a.lowerBound5h,  b.lowerBound5h)
+        XCTAssertEqual(a.upperBound5h,  b.upperBound5h)
+    }
+
+    // MARK: - Output invariants
+
+    func testConfidenceIsAlwaysWithinZeroToOne() {
+        let history = makeHistory([
+            (hoursAgo: 3, pct5h: 20, pct7d: 30),
+            (hoursAgo: 2, pct5h: 60, pct7d: 10),  // noisy
+            (hoursAgo: 1, pct5h: 10, pct7d: 80),
+        ])
+        let forecast = service.forecast(
+            history: history,
+            current: makeResponse(fiveHour: 50, sevenDay: 45),
+            now: now
+        )
+        XCTAssertGreaterThanOrEqual(forecast.confidence5h, 0)
+        XCTAssertLessThanOrEqual(forecast.confidence5h, 1)
+        XCTAssertGreaterThanOrEqual(forecast.confidence7d, 0)
+        XCTAssertLessThanOrEqual(forecast.confidence7d, 1)
+    }
+
+    func testPredictionBoundsAreOrderedAndClamped() {
+        let history = makeHistory([
+            (hoursAgo: 3, pct5h: 20, pct7d: 30),
+            (hoursAgo: 2, pct5h: 30, pct7d: 35),
+            (hoursAgo: 1, pct5h: 40, pct7d: 40),
+        ])
+        let forecast = service.forecast(
+            history: history,
+            current: makeResponse(fiveHour: 50, sevenDay: 45),
+            now: now
+        )
+        XCTAssertLessThanOrEqual(forecast.lowerBound5h, forecast.projected5h)
+        XCTAssertGreaterThanOrEqual(forecast.upperBound5h, forecast.projected5h)
+        XCTAssertGreaterThanOrEqual(forecast.lowerBound5h, 0)
+        XCTAssertLessThanOrEqual(forecast.upperBound5h, 100)
+
+        XCTAssertLessThanOrEqual(forecast.lowerBound7d, forecast.projected7d)
+        XCTAssertGreaterThanOrEqual(forecast.upperBound7d, forecast.projected7d)
+        XCTAssertGreaterThanOrEqual(forecast.lowerBound7d, 0)
+        XCTAssertLessThanOrEqual(forecast.upperBound7d, 100)
+    }
+
+    func testEffectiveWindowIsPositive() {
+        let history = makeHistory([
+            (hoursAgo: 3, pct5h: 20, pct7d: 30),
+            (hoursAgo: 2, pct5h: 30, pct7d: 35),
+            (hoursAgo: 1, pct5h: 40, pct7d: 40),
+        ])
+        let forecast = service.forecast(
+            history: history,
+            current: makeResponse(fiveHour: 50, sevenDay: 45),
+            now: now
+        )
+        XCTAssertGreaterThan(forecast.effectiveWindow5h, 0)
+        XCTAssertGreaterThan(forecast.effectiveWindow7d, 0)
+    }
+}


### PR DESCRIPTION
Fixes #42.

## Problem

When macOS reboots, it does not reliably deliver `NSApplication.willTerminateNotification` to login-item apps before force-killing them. The previous approach batched writes behind a 5-minute timer and relied on that notification as a safety flush — meaning up to 5 minutes of history could be lost on every ungraceful shutdown.

## Solution

Flush `history.json` to disk immediately inside `recordDataPoint()`, every time a data point is recorded. This eliminates the data-loss window entirely regardless of shutdown cause (reboot, force kill, kernel panic, power loss).

With the default 30-minute polling interval this is ~48 atomic writes per day — negligible overhead. `willTerminateNotification` is kept as a belt-and-suspenders safety flush.

## Changes

- `UsageHistoryService.swift` only — net **+1 / −20 lines**
- Removes: `isDirty`, `flushTimer`, `flushInterval`, `startFlushTimerIfNeeded()`, `import Combine`
- `flushToDisk()` is now always called directly from `recordDataPoint()`