### PR TITLE
Fix history loss on reboot: flush to disk on every data point

### DIFF
--- a/macos/Sources/ClaudeUsageBar/UsageHistoryService.swift
+++ b/macos/Sources/ClaudeUsageBar/UsageHistoryService.swift
@@ -1,17 +1,13 @@
 import Foundation
-import Combine
 import AppKit
 
 @MainActor
 class UsageHistoryService: ObservableObject {
     @Published var history = UsageHistory()
 
-    private var flushTimer: AnyCancellable?
-    private var isDirty = false
     private var terminationObserver: Any?
 
     private static let retentionInterval: TimeInterval = 30 * 86400 // 30 days
-    private static let flushInterval: TimeInterval = 300 // 5 minutes
 
     private static var historyFileURL: URL {
         let dir = FileManager.default.homeDirectoryForCurrentUser
@@ -63,31 +59,16 @@ class UsageHistoryService: ObservableObject {
     func recordDataPoint(pct5h: Double, pct7d: Double) {
         let point = UsageDataPoint(pct5h: pct5h, pct7d: pct7d)
         history.dataPoints.append(point)
-        isDirty = true
-        startFlushTimerIfNeeded()
+        flushToDisk()
     }
 
     // MARK: - Flush
 
     func flushToDisk() {
-        guard isDirty else { return }
         history.dataPoints = pruned(history.dataPoints)
 
         guard let data = try? JSONEncoder.historyEncoder.encode(history) else { return }
         try? data.write(to: Self.historyFileURL, options: .atomic)
-
-        isDirty = false
-        flushTimer?.cancel()
-        flushTimer = nil
-    }
-
-    private func startFlushTimerIfNeeded() {
-        guard flushTimer == nil else { return }
-        flushTimer = Timer.publish(every: Self.flushInterval, on: .main, in: .common)
-            .autoconnect()
-            .sink { [weak self] _ in
-                self?.flushToDisk()
-            }
     }
 
     // MARK: - Downsampling


### PR DESCRIPTION
Fixes #42.

## Problem

When macOS reboots, it does not reliably deliver `NSApplication.willTerminateNotification` to login-item apps before force-killing them. The previous approach batched writes behind a 5-minute timer and relied on that notification as a safety flush — meaning up to 5 minutes of history could be lost on every ungraceful shutdown.

## Solution

Flush `history.json` to disk immediately inside `recordDataPoint()`, every time a data point is recorded. This eliminates the data-loss window entirely regardless of shutdown cause (reboot, force kill, kernel panic, power loss).

With the default 30-minute polling interval this is ~48 atomic writes per day — negligible overhead. `willTerminateNotification` is kept as a belt-and-suspenders safety flush.

## Changes

- `UsageHistoryService.swift` only — net **+1 / −20 lines**
- Removes: `isDirty`, `flushTimer`, `flushInterval`, `startFlushTimerIfNeeded()`, `import Combine`
- `flushToDisk()` is now called directly from `recordDataPoint()`