### PR TITLE
Add 5-hour usage projection graph and run-out estimate

### DIFF
--- a/macos/Sources/ClaudeUsageBar/PopoverView.swift
+++ b/macos/Sources/ClaudeUsageBar/PopoverView.swift
@@ -94,6 +94,11 @@ struct PopoverView: View {
         Divider()
         UsageChartView(historyService: historyService)
 
+        if service.usage?.fiveHour != nil {
+            Divider()
+            ProjectionChartView(service: service, historyService: historyService)
+        }
+
         if let error = service.lastError {
             Divider()
             Label(error, systemImage: "exclamationmark.triangle")

--- a/macos/Sources/ClaudeUsageBar/ProjectionChartView.swift
+++ b/macos/Sources/ClaudeUsageBar/ProjectionChartView.swift
@@ -1,0 +1,165 @@
+import SwiftUI
+import Charts
+
+/// A forward-looking "when will the 5-hour window run out?" panel: a one-line status plus a
+/// projection chart spanning now → the next 5h reset, with a red rule at the projected run-out.
+struct ProjectionChartView: View {
+    @ObservedObject var service: UsageService
+    @ObservedObject var historyService: UsageHistoryService
+
+    var body: some View {
+        // Re-evaluate every minute so "now", the countdown, and the red line stay live while
+        // the popover is open, independent of the (possibly slow) poll cadence.
+        TimelineView(.periodic(from: .now, by: 60)) { context in
+            content(now: context.date)
+        }
+    }
+
+    @ViewBuilder
+    private func content(now: Date) -> some View {
+        let projection = UsageProjection.compute(
+            points: historyService.history.dataPoints,
+            currentPct: service.pct5h,
+            reset: service.reset5h,
+            pollingMinutes: service.pollingMinutes,
+            now: now
+        )
+
+        VStack(alignment: .leading, spacing: 8) {
+            statusText(for: projection.outcome)
+
+            if let reset = projection.reset, projection.outcome != .insufficientData {
+                chart(projection: projection, reset: reset)
+            }
+        }
+    }
+
+    // MARK: - Status line
+
+    @ViewBuilder
+    private func statusText(for outcome: UsageProjection.Outcome) -> some View {
+        switch outcome {
+        case .insufficientData:
+            Text("Not enough data to project yet")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        case .lastsUntilReset:
+            Label("Lasts until reset", systemImage: "checkmark.circle")
+                .font(.subheadline)
+                .foregroundStyle(.green)
+        case .runsOut(let date):
+            Label("Projected to run out at \(date, format: .dateTime.hour().minute())",
+                  systemImage: "exclamationmark.triangle")
+                .font(.subheadline)
+                .foregroundStyle(.red)
+        }
+    }
+
+    // MARK: - Chart
+
+    private struct ProjPoint: Identifiable {
+        let id = UUID()
+        let date: Date
+        let pct: Double
+    }
+
+    /// Drawing parameters derived from a projection (kept out of the `@ViewBuilder` so the
+    /// imperative branching below is treated as plain code, not view content).
+    private struct ChartGeometry {
+        let points: [ProjPoint]
+        let color: Color
+        let runsOutDate: Date?
+        let now: Date
+        let startPct: Double
+    }
+
+    private func geometry(projection: UsageProjection, reset: Date) -> ChartGeometry {
+        let now = projection.now
+        let startPct = projection.currentPct * 100
+
+        // The projection line ends at the crossing (if it runs out before reset) or at the
+        // reset edge (staying below 100% — visually confirming "lasts until reset").
+        let endDate: Date
+        let endPct: Double
+        var runsOutDate: Date?
+        if case .runsOut(let date) = projection.outcome {
+            endDate = date
+            endPct = 100
+            runsOutDate = date
+        } else {
+            endDate = reset
+            let projected = projection.currentPct + projection.ratePerSecond * reset.timeIntervalSince(now)
+            endPct = min(max(projected * 100, 0), 100)
+        }
+
+        return ChartGeometry(
+            points: [ProjPoint(date: now, pct: startPct), ProjPoint(date: endDate, pct: endPct)],
+            color: runsOutDate != nil ? .red : .green,
+            runsOutDate: runsOutDate,
+            now: now,
+            startPct: startPct
+        )
+    }
+
+    @ViewBuilder
+    private func chart(projection: UsageProjection, reset: Date) -> some View {
+        let geo = geometry(projection: projection, reset: reset)
+
+        Chart {
+            // 100% limit reference.
+            RuleMark(y: .value("Limit", 100))
+                .foregroundStyle(.secondary.opacity(0.3))
+                .lineStyle(StrokeStyle(lineWidth: 1, dash: [2, 2]))
+
+            // Projected trajectory (dashed).
+            ForEach(geo.points) { point in
+                LineMark(
+                    x: .value("Time", point.date),
+                    y: .value("Usage", point.pct)
+                )
+                .foregroundStyle(geo.color)
+                .interpolationMethod(.linear)
+                .lineStyle(StrokeStyle(lineWidth: 2, dash: [4, 3]))
+            }
+
+            // Current usage marker at "now".
+            PointMark(
+                x: .value("Time", geo.now),
+                y: .value("Usage", geo.startPct)
+            )
+            .foregroundStyle(geo.color)
+            .symbolSize(28)
+
+            // Red vertical line at the projected run-out time (clock time shown in the status).
+            if let runsOutDate = geo.runsOutDate {
+                RuleMark(x: .value("Runs out", runsOutDate))
+                    .foregroundStyle(.red)
+                    .lineStyle(StrokeStyle(lineWidth: 1.5))
+            }
+        }
+        .chartXScale(domain: geo.now...reset)
+        .chartYScale(domain: 0...100)
+        .chartYAxis {
+            AxisMarks(values: [0, 50, 100]) { value in
+                AxisValueLabel {
+                    if let v = value.as(Int.self) {
+                        Text("\(v)%").font(.caption2)
+                    }
+                }
+                AxisGridLine()
+            }
+        }
+        .chartXAxis {
+            AxisMarks(values: .automatic(desiredCount: 3)) { _ in
+                AxisValueLabel(format: Date.FormatStyle.dateTime.hour().minute())
+                    .font(.caption2)
+                AxisGridLine()
+            }
+        }
+        .chartPlotStyle { plot in
+            plot.clipped()
+        }
+        .frame(height: 100)
+        .padding(.top, 4)
+    }
+}

--- a/macos/Sources/ClaudeUsageBar/UsageProjection.swift
+++ b/macos/Sources/ClaudeUsageBar/UsageProjection.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// Forward-looking projection of when the 5-hour usage window will reach 100%, based on
+/// the recent burn rate. Pure and testable — no UI or service dependencies.
+///
+/// The rate is measured over the samples in a trailing window that tracks the user's poll
+/// cadence: since one history point is recorded per poll, "recent samples" are naturally
+/// spaced at the polling interval (5-min polling → ~5-min rate, 30-min polling → ~30-min rate).
+struct UsageProjection: Equatable {
+    enum Outcome: Equatable {
+        /// Not enough samples, or no forward reset horizon, to compute a projection.
+        case insufficientData
+        /// Usage is flat/declining, or would only cross 100% after the window resets.
+        case lastsUntilReset
+        /// Usage is rising and is projected to reach 100% at this time, before the reset.
+        case runsOut(at: Date)
+    }
+
+    let outcome: Outcome
+    /// Change in the 0…1 fraction per second over the measured window (may be ≤ 0).
+    let ratePerSecond: Double
+    /// Current 5-hour usage as a 0…1 fraction, anchored to `now`.
+    let currentPct: Double
+    let now: Date
+    let reset: Date?
+
+    /// Computes a projection for the 5-hour window.
+    ///
+    /// - Parameters:
+    ///   - points: recorded history samples (any order); only `pct5h`/`timestamp` are used.
+    ///   - currentPct: the freshest 5h fraction (0…1), e.g. `UsageService.pct5h`.
+    ///   - reset: when the 5h window next resets (`UsageService.reset5h`).
+    ///   - pollingMinutes: the user's poll cadence; the rate window adapts to it.
+    ///   - now: the reference "now".
+    static func compute(
+        points: [UsageDataPoint],
+        currentPct: Double,
+        reset: Date?,
+        pollingMinutes: Int,
+        now: Date = Date()
+    ) -> UsageProjection {
+        let base = min(max(currentPct, 0), 1)
+
+        // Need at least two samples and a reset that lies in the future to draw a timeline.
+        guard let reset, reset > now, points.count >= 2 else {
+            return UsageProjection(outcome: .insufficientData, ratePerSecond: 0,
+                                   currentPct: base, now: now, reset: reset)
+        }
+
+        let sorted = points.sorted { $0.timestamp < $1.timestamp }
+
+        // Rate window tracks the poll cadence (min 5 min). Use the samples inside the trailing
+        // window; if fewer than two land there, fall back to the last two samples overall.
+        let window = TimeInterval(max(pollingMinutes, 5) * 60)
+        let cutoff = now.addingTimeInterval(-window)
+        var recent = sorted.filter { $0.timestamp >= cutoff }
+        if recent.count < 2 {
+            recent = Array(sorted.suffix(2))
+        }
+
+        guard let first = recent.first, let last = recent.last else {
+            return UsageProjection(outcome: .insufficientData, ratePerSecond: 0,
+                                   currentPct: base, now: now, reset: reset)
+        }
+
+        let span = last.timestamp.timeIntervalSince(first.timestamp)
+        guard span > 0 else {
+            return UsageProjection(outcome: .lastsUntilReset, ratePerSecond: 0,
+                                   currentPct: base, now: now, reset: reset)
+        }
+
+        let rate = (last.pct5h - first.pct5h) / span
+
+        // Anchor the current usage at `now` by extrapolating from the last sample, so the
+        // graph's left edge reflects "now" rather than the last poll time. The projected
+        // crossing time (below) is anchored to the last sample, so it stays fixed as `now`
+        // advances between polls — the red line doesn't drift.
+        let anchored = min(max(base + rate * now.timeIntervalSince(last.timestamp), 0), 1)
+
+        // Flat or declining → the window simply resets before it fills.
+        guard rate > 0 else {
+            return UsageProjection(outcome: .lastsUntilReset, ratePerSecond: rate,
+                                   currentPct: anchored, now: now, reset: reset)
+        }
+
+        let rawCrossing = last.timestamp.addingTimeInterval((1 - base) / rate)
+        let crossing = max(rawCrossing, now)
+        let outcome: Outcome = crossing >= reset ? .lastsUntilReset : .runsOut(at: crossing)
+
+        return UsageProjection(outcome: outcome, ratePerSecond: rate,
+                               currentPct: anchored, now: now, reset: reset)
+    }
+}

--- a/macos/Tests/ClaudeUsageBarTests/UsageProjectionTests.swift
+++ b/macos/Tests/ClaudeUsageBarTests/UsageProjectionTests.swift
@@ -1,0 +1,140 @@
+import XCTest
+@testable import ClaudeUsageBar
+
+final class UsageProjectionTests: XCTestCase {
+    private let base = Date(timeIntervalSince1970: 1_000_000)
+
+    func testInsufficientDataWithFewerThanTwoPoints() {
+        let points = [UsageDataPoint(timestamp: base, pct5h: 0.5, pct7d: 0.1)]
+        let p = UsageProjection.compute(
+            points: points, currentPct: 0.5,
+            reset: base.addingTimeInterval(3600), pollingMinutes: 5, now: base
+        )
+        XCTAssertEqual(p.outcome, .insufficientData)
+    }
+
+    func testInsufficientDataWithoutReset() {
+        let now = base.addingTimeInterval(300)
+        let points = [
+            UsageDataPoint(timestamp: base, pct5h: 0.2, pct7d: 0.1),
+            UsageDataPoint(timestamp: now, pct5h: 0.4, pct7d: 0.1),
+        ]
+        let p = UsageProjection.compute(
+            points: points, currentPct: 0.4, reset: nil, pollingMinutes: 5, now: now
+        )
+        XCTAssertEqual(p.outcome, .insufficientData)
+    }
+
+    func testInsufficientDataWhenResetInPast() {
+        let now = base.addingTimeInterval(300)
+        let points = [
+            UsageDataPoint(timestamp: base, pct5h: 0.2, pct7d: 0.1),
+            UsageDataPoint(timestamp: now, pct5h: 0.4, pct7d: 0.1),
+        ]
+        let p = UsageProjection.compute(
+            points: points, currentPct: 0.4,
+            reset: now.addingTimeInterval(-60), pollingMinutes: 5, now: now
+        )
+        XCTAssertEqual(p.outcome, .insufficientData)
+    }
+
+    func testFlatUsageLastsUntilReset() {
+        let now = base.addingTimeInterval(300)
+        let points = [
+            UsageDataPoint(timestamp: base, pct5h: 0.5, pct7d: 0.1),
+            UsageDataPoint(timestamp: now, pct5h: 0.5, pct7d: 0.1),
+        ]
+        let p = UsageProjection.compute(
+            points: points, currentPct: 0.5,
+            reset: now.addingTimeInterval(3600), pollingMinutes: 5, now: now
+        )
+        XCTAssertEqual(p.outcome, .lastsUntilReset)
+    }
+
+    func testDecliningUsageLastsUntilReset() {
+        let now = base.addingTimeInterval(300)
+        let points = [
+            UsageDataPoint(timestamp: base, pct5h: 0.8, pct7d: 0.1),
+            UsageDataPoint(timestamp: now, pct5h: 0.5, pct7d: 0.1),
+        ]
+        let p = UsageProjection.compute(
+            points: points, currentPct: 0.5,
+            reset: now.addingTimeInterval(3600), pollingMinutes: 5, now: now
+        )
+        XCTAssertEqual(p.outcome, .lastsUntilReset)
+        XCTAssertLessThan(p.ratePerSecond, 0)
+    }
+
+    func testRisingUsageRunsOutBeforeReset() {
+        // 0.5 → 0.6 over 5 min = +0.1 / 300s. Need +0.4 more to reach 1.0 ⇒ 1200s from `now`.
+        let now = base.addingTimeInterval(300)
+        let points = [
+            UsageDataPoint(timestamp: base, pct5h: 0.5, pct7d: 0.1),
+            UsageDataPoint(timestamp: now, pct5h: 0.6, pct7d: 0.1),
+        ]
+        let reset = now.addingTimeInterval(3 * 3600)
+        let p = UsageProjection.compute(
+            points: points, currentPct: 0.6, reset: reset, pollingMinutes: 5, now: now
+        )
+        guard case .runsOut(let date) = p.outcome else {
+            return XCTFail("expected runsOut, got \(p.outcome)")
+        }
+        XCTAssertEqual(date.timeIntervalSince(now), 1200, accuracy: 1)
+    }
+
+    func testRisingButSlowLastsUntilReset() {
+        // +0.01 over 5 min ⇒ reaching 1.0 from 0.5 takes ~15000s (~4.2h) > 1h reset.
+        let now = base.addingTimeInterval(300)
+        let points = [
+            UsageDataPoint(timestamp: base, pct5h: 0.49, pct7d: 0.1),
+            UsageDataPoint(timestamp: now, pct5h: 0.50, pct7d: 0.1),
+        ]
+        let p = UsageProjection.compute(
+            points: points, currentPct: 0.50,
+            reset: now.addingTimeInterval(3600), pollingMinutes: 5, now: now
+        )
+        XCTAssertEqual(p.outcome, .lastsUntilReset)
+    }
+
+    func testAlreadyMaxedRunsOutNow() {
+        let now = base.addingTimeInterval(300)
+        let points = [
+            UsageDataPoint(timestamp: base, pct5h: 0.9, pct7d: 0.1),
+            UsageDataPoint(timestamp: now, pct5h: 1.0, pct7d: 0.1),
+        ]
+        let reset = now.addingTimeInterval(3600)
+        let p = UsageProjection.compute(
+            points: points, currentPct: 1.0, reset: reset, pollingMinutes: 5, now: now
+        )
+        guard case .runsOut(let date) = p.outcome else {
+            return XCTFail("expected runsOut, got \(p.outcome)")
+        }
+        XCTAssertEqual(date.timeIntervalSince(now), 0, accuracy: 1)
+    }
+
+    func testRateWindowAdaptsToPollingInterval() {
+        // An old steep jump followed by recent flat usage. A 5-min window sees only the flat
+        // recent pair (lasts); a 30-min window includes the steep jump (runs out).
+        let now = base.addingTimeInterval(1800) // 30 min after base
+        let points = [
+            UsageDataPoint(timestamp: base, pct5h: 0.10, pct7d: 0.1),                        // t=0
+            UsageDataPoint(timestamp: base.addingTimeInterval(600), pct5h: 0.70, pct7d: 0.1), // t=10m (steep)
+            UsageDataPoint(timestamp: base.addingTimeInterval(1500), pct5h: 0.70, pct7d: 0.1),// t=25m (flat)
+            UsageDataPoint(timestamp: now, pct5h: 0.70, pct7d: 0.1),                          // t=30m (flat)
+        ]
+        let reset = now.addingTimeInterval(3600)
+
+        let p5 = UsageProjection.compute(
+            points: points, currentPct: 0.70, reset: reset, pollingMinutes: 5, now: now
+        )
+        XCTAssertEqual(p5.outcome, .lastsUntilReset,
+                       "5-min window should see only the flat recent samples")
+
+        let p30 = UsageProjection.compute(
+            points: points, currentPct: 0.70, reset: reset, pollingMinutes: 30, now: now
+        )
+        guard case .runsOut = p30.outcome else {
+            return XCTFail("30-min window includes the steep jump; expected runsOut, got \(p30.outcome)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a forward-looking projection for the **5-hour** usage window: a status line ("Projected to run out at 5:50 PM" or "Lasts until reset") plus a dedicated chart spanning now → the next reset, with a red line at the projected run-out time. The burn rate is measured from recent history samples and adapts to the polling interval (one sample per poll, so a 5-min poller gets a ~5-min rate). Core logic lives in a pure, unit-tested `UsageProjection` type; the UI is a new `ProjectionChartView`, wired into the popover below the existing history chart.

## Screenshots

_Not included_ — the popover's usage view requires real OAuth credentials and several accumulated poll samples to render the projection, so it can't be captured headlessly in this workspace. Happy to add a capture when run against the mock server locally.

## Test plan

- [ ] `make app` builds without errors
- [x] `swift build` succeeds
- [x] `swift test --filter UsageProjectionTests` — 9/9 pass (insufficient data, no/past reset, flat & declining → "lasts", rising → "runs out" at the expected time, already-maxed, and poll-window adaptation)
- [ ] Tested with mock server: drive rising 5h utilization across ≥2 polls → status flips to "Projected to run out at H:MM" and the red run-out line appears inside the now→reset window; a flat/`maxed` scenario shows "Lasts until reset"

_Note: the repo's `PollingOptionFormatterTests` show 7 pre-existing failures unrelated to this change (an OS-locale `"5min"` vs `"5m"` formatting quirk; they fail identically on a clean tree)._
